### PR TITLE
HEALPix support for imaging response

### DIFF
--- a/config/Makefile.linuxgcc
+++ b/config/Makefile.linuxgcc
@@ -17,19 +17,6 @@ ROOTCFLAGS    = $(shell root-config --cflags)
 ROOTLIBS      = $(shell root-config --libs)
 ROOTGLIBS     = $(shell root-config --glibs)
 
-# Compiler & linker options:
-CXX           = g++
-CXXFLAGS      = $(OPT) -std=c++11 -Wall -Wno-deprecated -fPIC -D_REENTRANT -I$(IN) -I$(CT) -I. $(ROOTCFLAGS) -D___LINUX___ -D___CLING___
-DEFINES       = -UHARDWARE
-LD            = g++
-LDFLAGS       = $(OPT) -D___LINUX___
-SOFLAGS       = -shared  
-LIBS          = $(ROOTLIBS) -lpthread -lThread -lMinuit -lGeom -lSpectrum -lTMVA
-GLIBS         = $(ROOTGLIBS) 
-DEPFLAGS      = -MM
-
-LINK          = ln -s -f
-
 # HEASoft
 HEACFLAGS     = 
 HEALIBS       =
@@ -48,6 +35,20 @@ ifeq ("$(shell pkg-config --exists healpix_cxx 1>&2 2> /dev/null; echo $$?)", "0
         HEALPIXCFLAGS += $(shell pkg-config --cflags healpix_cxx)
         HEALPIXLIBS += $(shell pkg-config --libs healpix_cxx)
 endif
+
+# Compiler & linker options:
+CXX           = g++
+CXXFLAGS      = $(OPT) -std=c++11 -Wall -Wno-deprecated -fPIC -D_REENTRANT -I$(IN) -I$(CT) -I. $(ROOTCFLAGS) $(HEACFLAGS) $(HEALPIXCFLAGS) -D___LINUX___ -D___CLING___
+DEFINES       = -UHARDWARE
+LD            = g++
+LDFLAGS       = $(OPT) -D___LINUX___
+SOFLAGS       = -shared  
+LIBS          = $(ROOTLIBS) $(HEALIBS) $(HEALPIXLIBS) -lpthread -lThread -lMinuit -lGeom -lSpectrum -lTMVA
+GLIBS         = $(ROOTGLIBS) 
+DEPFLAGS      = -MM
+
+LINK          = ln -s -f
+
 
 
 

--- a/config/Makefile.macosx
+++ b/config/Makefile.macosx
@@ -18,19 +18,6 @@ ROOTCFLAGS    = $(shell root-config --cflags)
 ROOTLIBS      = $(shell root-config --libs)
 ROOTGLIBS     = $(shell root-config --glibs)
 
-# Compiler & linker options:
-CXX           = c++
-CXXFLAGS      = $(OPT) -std=c++11 -pipe -Wall -fPIC -D_REENTRANT -I$(IN) -I$(CT) -I. $(ROOTCFLAGS) -D___MACOSX___ -D___CLING___ -Wno-overloaded-virtual -Wno-tautological-undefined-compare
-DEFINES       = -UHARDWARE
-LD            = c++
-LDFLAGS       = $(OPT) -Xlinker -bind_at_load -flat_namespace -D___MACOSX___
-SOFLAGS       = -dynamiclib -flat_namespace -undefined suppress 
-LIBS          = $(ROOTLIBS) -lpthread -lThread -lMinuit -lGeom -lSpectrum -lTMVA
-GLIBS         = $(ROOTGLIBS) 
-DEPFLAGS      = -M
-
-LINK          = ln -s -f
-
 # HEASoft
 HEACFLAGS     =
 HEALIBS       =
@@ -51,6 +38,18 @@ ifeq ("$(shell pkg-config --exists healpix_cxx 1>&2 2> /dev/null; echo $$?)", "0
 endif
 
 
+# Compiler & linker options:
+CXX           = c++
+CXXFLAGS      = $(OPT) -std=c++11 -pipe -Wall -fPIC -D_REENTRANT -I$(IN) -I$(CT) -I. $(ROOTCFLAGS) $(HEACFLAGS) $(HEALPIXCFLAGS) -D___MACOSX___ -D___CLING___ -Wno-overloaded-virtual -Wno-tautological-undefined-compare
+DEFINES       = -UHARDWARE
+LD            = c++
+LDFLAGS       = $(OPT) -Xlinker -bind_at_load -flat_namespace -D___MACOSX___
+SOFLAGS       = -dynamiclib -flat_namespace -undefined suppress 
+LIBS          = $(ROOTLIBS) $(HEALIBS) $(HEALPIXLIBS) -lpthread -lThread -lMinuit -lGeom -lSpectrum -lTMVA
+GLIBS         = $(ROOTGLIBS) 
+DEPFLAGS      = -M
+
+LINK          = ln -s -f
 
 # Modifications for MacPorts on Monterey
 ifneq ($(wildcard /opt/local/lib/libgcc),)

--- a/src/global/misc/Makefile
+++ b/src/global/misc/Makefile
@@ -152,7 +152,7 @@ $(DICTIONARY): $(HEADERS)
 	@echo "Generating $(DICTIONARYNAME)_LinkDef ..."
 	@$(BN)/generatelinkdef -o $(LINKDEF) -i $(HEADERS)
 	@echo "Generating dictionary ..."
-	@rootcling -f $@ -I$(IN) -D___CLING___ -rmf $(ROOTMAP) -s lib$(LIBRARY) -c $^ $(LINKDEF)
+	@rootcling -f $@ -I$(IN) $(HEALPIXCFLAGS) -D___CLING___ -rmf $(ROOTMAP) -s lib$(LIBRARY) -c $^ $(LINKDEF)
 	@mv $(ROOTPCM) $(LB)
 	@echo "Dictionary done ..."
 

--- a/src/global/misc/Makefile
+++ b/src/global/misc/Makefile
@@ -101,6 +101,7 @@ FILES = MGlobal \
 	MBinnerFixedCountsPerBin \
 	MBinnerBayesianBlocks \
 	MBinnerFISBEL \
+	MBinnerHEALPix \
 	MXmlData \
 	MXmlNode \
 	MXmlAttribute \

--- a/src/global/misc/inc/MBinnerFISBEL.h
+++ b/src/global/misc/inc/MBinnerFISBEL.h
@@ -22,6 +22,7 @@
 
 // MEGAlib libs:
 #include "MGlobal.h"
+#include "MBinnerSpherical.h"
 
 // Forward declarations:
 
@@ -30,7 +31,7 @@
 
 //! FISBEL: Fixed Integral Square Bins in Equi-longitude..?
 //! This is just the binner, it does not store any data itself
-class MBinnerFISBEL
+class MBinnerFISBEL : public MBinnerSpherical
 {
   // public interface:
  public:
@@ -45,10 +46,10 @@ class MBinnerFISBEL
   //! Set the binning
   void Set(vector<unsigned int>& LongitudeBins, vector<double>& LatitudeBinEdges, unsigned int NumberOfBins, double LongitudeShift = 0);
   
-  //! Check if we have equal bins
-  bool operator ==(const MBinnerFISBEL& Binner) const;
-  //! ... or not
-  bool operator !=(const MBinnerFISBEL& Binner) const { return !operator==(Binner); }
+  // //! Check if we have equal bins
+  // bool operator ==(const MBinnerFISBEL& Binner) const;
+  // //! ... or not
+  // bool operator !=(const MBinnerFISBEL& Binner) const { return !operator==(Binner); }
   
   //! Find a bin
   //! Theta (= latitude) and phi (= longitude) are in (mathematical) spherical coordinates
@@ -68,7 +69,13 @@ class MBinnerFISBEL
   
   //! Get the latitude bin edges (in degree)
   vector<double> GetLatitudeBinEdges() const { return m_LatitudeBinEdges; } 
-  
+
+  //! Return the minimum axis values [min theta, min phi]
+  vector<double> GetMinima() const;
+
+  //! Return the minimum axis values [max theta, max phi]
+  vector<double> GetMaxima() const;
+
   //! Get the bin center (returns: theta, phi in radians)
   //! Can throw: MExceptionIndexOutOfBounds
   vector<double> GetBinCenters(unsigned int Bin) const;
@@ -82,6 +89,9 @@ class MBinnerFISBEL
   
   //! Return axis bins edges for external drawing (1st array: longitude/phi, 2nd array: latitude/theta)
   vector<vector<double>> GetDrawingAxisBinEdges() const;
+
+  //! Write the content to a stream
+  void Write(MString name, ostringstream& out) const;
   
   // protected methods:
  protected:

--- a/src/global/misc/inc/MBinnerHEALPix.h
+++ b/src/global/misc/inc/MBinnerHEALPix.h
@@ -1,0 +1,107 @@
+#ifndef __MBinnerHEALPix__
+#define __MBinnerHEALPix__
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+// Standard libs:
+
+// ROOT libs:
+
+// MEGAlib libs:
+#include "MGlobal.h"
+#include "MBinnerSpherical.h"
+
+// Forward declarations:
+
+// Other libs:
+#include <healpix_base.h>
+
+////////////////////////////////////////////////////////////////////////////////
+
+//! HEALPix: https://healpix.sourceforge.io/
+//! RING scheme by default
+//! This is just the binner, it does not store any data itself
+class MBinnerHEALPix : public MBinnerSpherical
+{
+  // public interface:
+ public:
+  //! Default constructor
+  MBinnerHEALPix(unsigned int order);
+  //! Default destuctor 
+  virtual ~MBinnerHEALPix();
+    
+  // //! Check if we have equal bins
+  // bool operator ==(const MBinnerFISBEL& Binner) const;
+  // //! ... or not
+  // bool operator !=(const MBinnerFISBEL& Binner) const { return !operator==(Binner); }
+  
+  //! Find a bin
+  //! Theta (= latitude) and phi (= longitude) are in (mathematical) spherical coordinates
+  //! The bins are arranged along the iso-latitude lines starting at the north pole (theta = latitude = 0)
+  //! Theta and phi are in radians!
+  unsigned int FindBin(double Theta, double Phi) const;
+  
+  //! Get number of bins
+  unsigned int GetNBins() const {return m_healpix.Npix();};
+  
+  //! Get NSIDE parameters
+  unsigned int GetNSide() const {return m_healpix.Nside();};
+
+  //! Get NSIDE parameters
+  unsigned int GetOrder() const {return m_healpix.Order();};    
+    
+  //! Return the minimum axis values [min theta, min phi]
+  vector<double> GetMinima() const;
+
+  //! Return the minimum axis values [max theta, max phi]
+  vector<double> GetMaxima() const;
+    
+  //! Get the bin center (returns: theta, phi in radians)
+  //! Can throw: MExceptionIndexOutOfBounds
+  vector<double> GetBinCenters(unsigned int Bin) const;
+  
+  //! Returns all bin centers as vector
+  vector<MVector> GetAllBinCenters() const;
+  
+  //! Return axis bins edges for external drawing (1st array: longitude/phi, 2nd array: latitude/theta)
+  vector<vector<double>> GetDrawingAxisBinEdges() const;
+
+  //! Write the content to a stream
+  void Write(MString name, ostringstream& out) const;
+  
+  // protected methods:
+ protected:
+
+
+  // private methods:
+ private:
+
+
+
+  // protected members:
+ protected:
+
+  // Healpix grid nside and scheme
+  Healpix_Base m_healpix; 
+    
+  // Scheme
+  // TODO
+    
+  // private members:
+ private:
+
+  
+#ifdef ___CLING___
+ public:
+  ClassDef(MBinnerHEALPix, 0) // no description
+#endif
+
+};
+
+#endif
+
+
+////////////////////////////////////////////////////////////////////////////////
+

--- a/src/global/misc/inc/MBinnerSpherical.h
+++ b/src/global/misc/inc/MBinnerSpherical.h
@@ -42,11 +42,6 @@ class MBinnerSpherical
     //! Write the content to a stream
     virtual void Write(MString name, ostringstream& out) const = 0;
     
-// #ifdef ___CLING___
-//  public:
-//   ClassDef(MBinnerSpherical, 0) // no description
-// #endif
-
 };
 
 #endif

--- a/src/global/misc/inc/MBinnerSpherical.h
+++ b/src/global/misc/inc/MBinnerSpherical.h
@@ -1,0 +1,57 @@
+#ifndef __MBinnerSpherical__
+#define __MBinnerSpherical__
+
+
+class MBinnerSpherical
+{
+
+  public :
+
+    MBinnerSpherical(){};
+    ~MBinnerSpherical(){};
+    
+    //! Find a bin
+    //! Theta (= latitude) and phi (= longitude) are in (mathematical) spherical coordinates
+    //! The bins are arranged along the iso-latitude lines starting at the north pole (theta = latitude = 0)
+    //! Theta and phi are in radians!
+    virtual unsigned int FindBin (double Theta, double Phi) const = 0;
+
+    //! Get number of bins
+    virtual unsigned int GetNBins() const  = 0;
+
+    //! Returns all bin centers as vector
+    virtual vector<double> GetBinCenters(unsigned int Bin) const = 0;
+
+    //! Returns all bin centers as vector
+    virtual vector<MVector> GetAllBinCenters() const = 0;
+
+    //! Return the minimum axis values [min theta, min phi]
+    virtual vector<double> GetMinima() const = 0;
+
+    //! Return the minimum axis values [max theta, max phi]
+    virtual vector<double> GetMaxima() const = 0;
+
+    //! Return axis bins edges for external drawing (1st array: longitude/phi, 2nd array: latitude/theta)
+    virtual vector<vector<double> > GetDrawingAxisBinEdges() const = 0;
+
+    // //! Check if we have equal bins
+    // virtual bool operator ==(const MBinnerSpherical&) const = 0;
+    // //! ... or not
+    // virtual bool operator !=(const MBinnerSpherical&) const = 0;
+  
+    //! Write the content to a stream
+    virtual void Write(MString name, ostringstream& out) const = 0;
+    
+// #ifdef ___CLING___
+//  public:
+//   ClassDef(MBinnerSpherical, 0) // no description
+// #endif
+
+};
+
+#endif
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+

--- a/src/global/misc/inc/MResponseMatrixAxisSpheric.h
+++ b/src/global/misc/inc/MResponseMatrixAxisSpheric.h
@@ -17,6 +17,7 @@
 
 
 // Standard libs:
+#include <memory>
 
 // ROOT libs:
 
@@ -24,6 +25,7 @@
 #include "MGlobal.h"
 #include "MResponseMatrixAxis.h"
 #include "MBinnerFISBEL.h"
+#include "MBinnerHEALPix.h"
 
 // Forward declarations:
 
@@ -41,10 +43,10 @@ class MResponseMatrixAxisSpheric : public MResponseMatrixAxis
   //! Default destuctor 
   virtual ~MResponseMatrixAxisSpheric();
   
-  //! Equality operator
-  bool operator==(const MResponseMatrixAxisSpheric& Axis) const;
-  //! Inequality operator
-  bool operator!=(const MResponseMatrixAxisSpheric& Axis) const { return !(operator==(Axis)); }
+  // //! Equality operator
+  // bool operator==(const MResponseMatrixAxisSpheric& Axis) const;
+  // //! Inequality operator
+  // bool operator!=(const MResponseMatrixAxisSpheric& Axis) const { return !(operator==(Axis)); }
 
   //! Clone this axis
   virtual MResponseMatrixAxisSpheric* Clone() const;
@@ -52,7 +54,15 @@ class MResponseMatrixAxisSpheric : public MResponseMatrixAxis
   //! Set the axis in FISBEL mode with a longitude shift in degrees
   void SetFISBEL(unsigned long NBins, double LongitudeShift = 0);
   
+  //! Set the axis in HEALPIX (ring scheme)
+  void SetHEALPix(unsigned long order);
 
+  //! Set the axis in FISBEL based on a target pixel size (deg)
+  void SetFISBELSize(double PixelSize);
+  
+  //! Set the axis in HEALPIX based on a target pixel size (deg)
+  void SetHEALPixSize(double PixelSize);  
+    
   //! Return the axis bin, given theta=latitude and phi=longitude in degrees
   virtual unsigned long GetAxisBin(double Theta, double Phi) const;
   
@@ -64,7 +74,7 @@ class MResponseMatrixAxisSpheric : public MResponseMatrixAxis
   //! Get the 1D bin edges
   //! Check with Has1DBinEdges first, because this is not guaranteed
   virtual vector<double> Get1DBinEdges() const { return vector<double>(); }
-  
+    
   //! Return the area of the given axis bin
   virtual double GetArea(unsigned long Bin) const;
   
@@ -99,7 +109,7 @@ class MResponseMatrixAxisSpheric : public MResponseMatrixAxis
   // private members:
  private:
   //! The binner
-  MBinnerFISBEL m_Binner;
+    std::shared_ptr<MBinnerSpherical> m_Binner;
   
 
 #ifdef ___CLING___

--- a/src/global/misc/src/MBinnerFISBEL.cxx
+++ b/src/global/misc/src/MBinnerFISBEL.cxx
@@ -64,16 +64,16 @@ MBinnerFISBEL::~MBinnerFISBEL()
 ////////////////////////////////////////////////////////////////////////////////
 
 
-//! Check if we have equal bins
-bool MBinnerFISBEL::operator==(const MBinnerFISBEL& Binner) const
-{
-  if (m_NumberOfBins != Binner.m_NumberOfBins) return false;
-  if (m_LongitudeBins != Binner.m_LongitudeBins) return false;
-  if (m_LatitudeBinEdges != Binner.m_LatitudeBinEdges) return false;
-  if (m_LongitudeShift != Binner.m_LongitudeShift) return false;
+// //! Check if we have equal bins
+// bool MBinnerFISBEL::operator==(const MBinnerFISBEL& Binner) const
+// {
+//   if (m_NumberOfBins != Binner.m_NumberOfBins) return false;
+//   if (m_LongitudeBins != Binner.m_LongitudeBins) return false;
+//   if (m_LatitudeBinEdges != Binner.m_LatitudeBinEdges) return false;
+//   if (m_LongitudeShift != Binner.m_LongitudeShift) return false;
   
-  return true;
-}
+//   return true;
+// }
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -430,6 +430,32 @@ void MBinnerFISBEL::View(vector<double> Data) const
   gSystem->ProcessEvents();
 }
 
+//! Return the minimum axis values
+vector<double> MBinnerFISBEL::GetMinima() const
+{
+  return { 0, GetLongitudeShift() };
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+//! Return the minimum axis values
+vector<double> MBinnerFISBEL::GetMaxima() const
+{
+  return { 180, GetLongitudeShift() + 360 };
+}
+
+void MBinnerFISBEL::Write(MString name, ostringstream& out) const
+{
+  out<<"# Axis name"<<endl;
+  out<<"AN \"" << name << "\""<<endl;
+  out<<"# Axis type"<<endl;
+  out<<"AT 2D FISBEL"<<endl;
+  out<<"# Axis data"<<endl;
+  out<<"AD "<< GetNBins() << "  " << GetLongitudeShift() * c_Deg<<endl;
+}  
 
 // MBinnerFISBEL.cxx: the end...
 ////////////////////////////////////////////////////////////////////////////////
+

--- a/src/global/misc/src/MBinnerHEALPix.cxx
+++ b/src/global/misc/src/MBinnerHEALPix.cxx
@@ -1,5 +1,6 @@
 // Include the header:
 #include "MBinnerHEALPix.h"
+#include "MExceptions.h"
 
 // Standard libs:
 #include <vector>
@@ -53,7 +54,8 @@ unsigned int MBinnerHEALPix::FindBin(double Theta, double Phi) const
 //! Return axis bins edges for external drawing
 vector<vector<double>> MBinnerHEALPix::GetDrawingAxisBinEdges() const
 {
-
+    throw MExceptionArbitrary("GetDrawingAxisBinEdges not implemented for HEALPix");
+    return {{}};
 }
 
 //! Return the bin center(s) of the given axis bin

--- a/src/global/misc/src/MBinnerHEALPix.cxx
+++ b/src/global/misc/src/MBinnerHEALPix.cxx
@@ -1,0 +1,115 @@
+// Include the header:
+#include "MBinnerHEALPix.h"
+
+// Standard libs:
+#include <vector>
+#include <iostream>
+#include <algorithm>
+using namespace std;
+
+// Other libs
+#include <pointing.h>
+
+#ifdef ___CLING___
+ClassImp(MBinnerHEALPix)
+#endif
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+//! Default constructor
+MBinnerHEALPix::MBinnerHEALPix(unsigned int order)
+{
+  m_healpix = Healpix_Base(order, Healpix_Ordering_Scheme::RING);
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+//! Default destructor
+MBinnerHEALPix::~MBinnerHEALPix()
+{
+}
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+//! Find a bin
+unsigned int MBinnerHEALPix::FindBin(double Theta, double Phi) const
+{
+
+  pointing p(Theta, Phi);
+
+  int pix = m_healpix.ang2pix(p);
+  
+  return pix;
+}
+
+
+//! Return axis bins edges for external drawing
+vector<vector<double>> MBinnerHEALPix::GetDrawingAxisBinEdges() const
+{
+
+}
+
+//! Return the bin center(s) of the given axis bin
+//! Can throw: MExceptionIndexOutOfBounds
+vector<double> MBinnerHEALPix::GetBinCenters(unsigned int Bin) const
+{
+  pointing p = m_healpix.pix2ang(Bin);
+
+  return {p.theta, p.phi};
+}
+
+
+//! Returns all bin centers as vector
+vector<MVector> MBinnerHEALPix::GetAllBinCenters() const
+{
+  vector<MVector> Vectors;
+  
+  for (unsigned int b = 0; b < GetNBins(); ++b) {
+    vector<double> Centers = GetBinCenters(b);
+    
+    MVector V;
+    V.SetMagThetaPhi(1.0, Centers[0], Centers[1]);
+    Vectors.push_back(V);
+  }
+  
+  return Vectors;
+ 
+}
+
+//! Return the minimum axis values
+vector<double> MBinnerHEALPix::GetMinima() const
+{
+  return { 0, 0};
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+//! Return the minimum axis values
+vector<double> MBinnerHEALPix::GetMaxima() const
+{
+  return { 180, 360 };
+}
+
+
+void MBinnerHEALPix::Write(MString name, ostringstream& out) const
+{
+  out<<"# Axis name"<<endl;
+  out<<"AN \"" << name << "\""<<endl;
+  out<<"# Axis type"<<endl;
+  out<<"AT 2D HEALPix"<<endl;
+  out<<"# Axis data"<<endl;
+  out<<"AD "<< GetOrder() << "  " << "RING" << endl;
+}  
+
+// MBinnerHEALPix.cxx: the end...
+////////////////////////////////////////////////////////////////////////////////
+

--- a/src/global/misc/src/MResponseMatrixAxisSpheric.cxx
+++ b/src/global/misc/src/MResponseMatrixAxisSpheric.cxx
@@ -139,6 +139,11 @@ void MResponseMatrixAxisSpheric::SetHEALPixSize(double PixelSize) {
 
   int order = int(ceil(log2(approx_nside)));
 
+  if (order < 1) {
+    // e.g. PixelSize = 360deg
+    order = 1;
+  }
+  
   SetHEALPix(order);
   
 }

--- a/src/global/misc/src/MResponseMatrixAxisSpheric.cxx
+++ b/src/global/misc/src/MResponseMatrixAxisSpheric.cxx
@@ -20,6 +20,8 @@
 #include "MResponseMatrixAxisSpheric.h"
 
 // Standard libs:
+#include <math.h>
+using namespace std;
 
 // ROOT libs:
 
@@ -43,7 +45,6 @@ MResponseMatrixAxisSpheric::MResponseMatrixAxisSpheric(const MString& ThetaAxisN
 {
   m_Dimension = 2;
   m_Names.push_back(PhiAxisName);
-  m_Binner.Create(1);
 }
 
 
@@ -77,20 +78,20 @@ MResponseMatrixAxisSpheric* MResponseMatrixAxisSpheric::Clone() const
 
 
 //! Equality operator
-bool MResponseMatrixAxisSpheric::operator==(const MResponseMatrixAxisSpheric& Axis) const
-{
-  // We don't care about names, only the physical properties
+// bool MResponseMatrixAxisSpheric::operator==(const MResponseMatrixAxisSpheric& Axis) const
+// {
+//   // We don't care about names, only the physical properties
   
-  if (m_Dimension != Axis.m_Dimension) {
-    return false;
-  }
+//   if (m_Dimension != Axis.m_Dimension) {
+//     return false;
+//   }
   
-  if (m_Binner != Axis.m_Binner) {
-    return false;
-  }
+//   if (*m_Binner != *Axis.m_Binner) {
+//     return false;
+//   }
   
-  return true;
-}
+//   return true;
+// }
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -99,8 +100,47 @@ bool MResponseMatrixAxisSpheric::operator==(const MResponseMatrixAxisSpheric& Ax
 //! Set the axis in FISBEL mode
 void MResponseMatrixAxisSpheric::SetFISBEL(unsigned long NBins, double LongitudeShift) 
 {
-  m_Binner.Create(NBins, LongitudeShift*c_Rad);
+  
+  std::shared_ptr<MBinnerFISBEL> m_Binner_fisbel = std::make_shared<MBinnerFISBEL>();
+  m_Binner_fisbel->Create(NBins, LongitudeShift*c_Rad);
+  
+  m_Binner = m_Binner_fisbel;
+
   m_NumberOfBins = NBins;
+}
+
+// //! Set the axis in HEALPix mode (ring scheme)
+void MResponseMatrixAxisSpheric::SetHEALPix(unsigned long order) 
+{
+
+  std::shared_ptr<MBinnerHEALPix> m_Binner_healpix = std::make_shared<MBinnerHEALPix>(order);
+
+  m_Binner = m_Binner_healpix;
+
+  m_NumberOfBins = m_Binner->GetNBins();
+  
+}
+
+
+//! Set the axis in FISBEL based on a target pixel size
+void MResponseMatrixAxisSpheric::SetFISBELSize(double PixelSize) {
+
+  int AngleBins = 4*c_Pi*c_Deg*c_Deg / PixelSize / PixelSize;
+  if (AngleBins < 1) AngleBins = 1;
+
+  SetFISBEL(AngleBins);
+
+}
+
+//! Set the axis in HEALPIX based on a target pixel size
+void MResponseMatrixAxisSpheric::SetHEALPixSize(double PixelSize) {
+
+  double approx_nside = sqrt(4*c_Pi/12)/(PixelSize/c_Deg);
+
+  int order = int(ceil(log2(approx_nside)));
+
+  SetHEALPix(order);
+  
 }
 
 
@@ -110,7 +150,7 @@ void MResponseMatrixAxisSpheric::SetFISBEL(unsigned long NBins, double Longitude
 //! Return the axis bin, given theta=latitude and phi=longitude 
 unsigned long MResponseMatrixAxisSpheric::GetAxisBin(double Theta, double Phi) const
 {
-  return m_Binner.FindBin(Theta*c_Rad, Phi*c_Rad);
+  return m_Binner->FindBin(Theta*c_Rad, Phi*c_Rad);
 }
 
 
@@ -120,7 +160,7 @@ unsigned long MResponseMatrixAxisSpheric::GetAxisBin(double Theta, double Phi) c
 //! Return the area of the given axis bin
 double MResponseMatrixAxisSpheric::GetArea(unsigned long Bin) const
 {
-  return 4*c_Pi/m_Binner.GetNBins() * c_Deg*c_Deg;
+  return 4*c_Pi/m_Binner->GetNBins() * c_Deg*c_Deg;
 }
 
 
@@ -130,7 +170,7 @@ double MResponseMatrixAxisSpheric::GetArea(unsigned long Bin) const
 //! Return the axis bins for drawing --- those might be narrower than the real bins
 vector<vector<double>> MResponseMatrixAxisSpheric::GetDrawingAxisBinEdges() const
 {
-  vector<vector<double>> AxisBinEdges = m_Binner.GetDrawingAxisBinEdges();
+  vector<vector<double>> AxisBinEdges = m_Binner->GetDrawingAxisBinEdges();
   AxisBinEdges.push_back(AxisBinEdges[0]);
   AxisBinEdges.erase(AxisBinEdges.begin());
   
@@ -163,7 +203,7 @@ bool MResponseMatrixAxisSpheric::InRange(double Theta, double Phi) const
 //! Return the minimum axis values
 vector<double> MResponseMatrixAxisSpheric::GetMinima() const
 {
-  return { 0, m_Binner.GetLongitudeShift() };
+  return m_Binner->GetMinima();
 }
 
 
@@ -173,7 +213,7 @@ vector<double> MResponseMatrixAxisSpheric::GetMinima() const
 //! Return the minimum axis values
 vector<double> MResponseMatrixAxisSpheric::GetMaxima() const
 {
-  return { 180, m_Binner.GetLongitudeShift() + 360 };
+  return m_Binner->GetMaxima();
 }
 
 
@@ -188,7 +228,7 @@ vector<double> MResponseMatrixAxisSpheric::GetBinCenters(unsigned long Bin) cons
     throw MExceptionIndexOutOfBounds(0, m_BinEdges.size() - 1, Bin);
   }
   
-  vector<double> Centers = m_Binner.GetBinCenters(Bin);
+  vector<double> Centers = m_Binner->GetBinCenters(Bin);
   Centers[0] *= c_Deg;
   Centers[1] *= c_Deg;
   
@@ -203,7 +243,7 @@ vector<double> MResponseMatrixAxisSpheric::GetBinCenters(unsigned long Bin) cons
 //! Can throw: MExceptionIndexOutOfBounds
 vector<MVector> MResponseMatrixAxisSpheric::GetAllBinCenters() const
 {
-  return m_Binner.GetAllBinCenters();
+  return m_Binner->GetAllBinCenters();
 }
 
 
@@ -213,12 +253,11 @@ vector<MVector> MResponseMatrixAxisSpheric::GetAllBinCenters() const
 //! Write the content to a stream
 void MResponseMatrixAxisSpheric::Write(ostringstream& out)
 {
-  out<<"# Axis name"<<endl;
-  out<<"AN \""<<m_Names[0]<<"\" \""<<m_Names[1]<<"\""<<endl;
-  out<<"# Axis type"<<endl;
-  out<<"AT 2D FISBEL"<<endl;
-  out<<"# Axis data"<<endl;
-  out<<"AD "<<m_Binner.GetNBins()<<"  "<<m_Binner.GetLongitudeShift() * c_Deg<<endl;
+
+  MString name = m_Names[0] + "\" \"" + m_Names[1];
+  
+  m_Binner->Write(name, out);
+  
 }
 
 

--- a/src/global/misc/src/MResponseMatrixON.cxx
+++ b/src/global/misc/src/MResponseMatrixON.cxx
@@ -1354,6 +1354,32 @@ bool MResponseMatrixON::ReadSpecific(MFileResponse& Parser,
                 break;
               }
             }
+          } else if (Type == "2D HEALPix") {
+            if (AxisName.size() != 2) {
+              mout<<"MResponseMatrixON: Did not find two axis names for the response matrix axis!"<<endl;
+              return false;
+            }
+            MResponseMatrixAxisSpheric* A = new MResponseMatrixAxisSpheric(AxisName[0], AxisName[1]);
+            // Sub parse until we found the axis data
+            while (Parser.TokenizeLine(T, true) == true) {
+              if (T.GetNTokens() < 2) continue;
+              if (T.GetTokenAt(0) == "AD") {
+                if (T.GetNTokens() == 2) {
+
+                  if (T.GetTokenAfterAsString(2) != "RING") {
+                  mout<<"MResponseMatrixON: Only HEALPix RING scheme supported for now!"<<endl;
+                  return false;
+                  }
+                  
+                  A->SetHEALPix(T.GetTokenAtAsUnsignedInt(1));
+                } else {
+                  mout<<"MResponseMatrixON: The HEALPix AD axis key word needs 2 (order and scheme) arguments!"<<endl;
+                  return false;
+                }
+                m_Axes.push_back(A);
+                break;
+              }
+            }
           }
         }
         break;

--- a/src/response/inc/MResponseImagingBinnedMode.h
+++ b/src/response/inc/MResponseImagingBinnedMode.h
@@ -76,8 +76,12 @@ class MResponseImagingBinnedMode : public MResponseBuilder
  protected:
   //! The bin width of the angles near the equator for the gamma rays
   double m_AngleBinWidth;
+  //! fisbel or healpix
+  std::string m_AngleBinMode;
   //! The bin width of the angles near the equator for the recoil electron (360 for no electron tracking)
   double m_AngleBinWidthElectron;
+  //! fisbel or healpix
+  std::string m_AngleBinModeElectron;
   //! Number of energy bins
   unsigned int m_EnergyNBins;
   //! Minimum energy range

--- a/src/response/src/MResponseImagingBinnedMode.cxx
+++ b/src/response/src/MResponseImagingBinnedMode.cxx
@@ -58,6 +58,8 @@ MResponseImagingBinnedMode::MResponseImagingBinnedMode() : m_ImagingResponse(tru
   
   m_AngleBinWidth = 5; // deg
   m_AngleBinWidthElectron = 360; // deg
+  m_AngleBinMode = "fisbel"; 
+  m_AngleBinModeElectron = "fisbel";
   m_EnergyNBins = 1;
   m_EnergyMinimum = 10; // keV
   m_EnergyMaximum = 2000; // keV
@@ -100,10 +102,12 @@ MString MResponseImagingBinnedMode::Options()
 {
   ostringstream out;
   out<<"             anglebinwidth:           the width of a sky bin at the equator (default: 5 deg)"<<endl;
+  out<<"             anglebinmode:            use either FISBEL or HEALPIx (default: FISBEL)"<<endl;
   out<<"             emin:                    minimum energy (default: 10 keV; cannot be used in combination with ebinedges)"<<endl;
   out<<"             emax:                    maximum energy (default: 2,000 keV; cannot be used in combination with ebinedges)"<<endl;
   out<<"             ebins:                   number of energy bins between min and max energy (default: 1; cannot be used in combination with ebinedges)"<<endl;
   out<<"             ebinedges:               the energy bin edges as a comma seperated list (default: not used, cannot be used in combination with emin, emax, or ebins)"<<endl;
+  out<<"             anglebinmodeelectron:    use either FISBEL or HEALPIx (default: FISBEL)"<<endl;
   out<<"             anglebinwidthelectron:   the width of a aky bin at the equator (default: 5 deg)"<<endl;
   out<<"             dmin:                    minimum distance (default: 0 cm)"<<endl;
   out<<"             dmax:                    maximum distance (default: 1,000 cm)"<<endl;
@@ -170,7 +174,8 @@ bool MResponseImagingBinnedMode::ParseOptions(const MString& Options)
     
   // Parse
   for (unsigned int i = 0; i < Split2.size(); ++i) {
-    string Value = Split2[i][1].Data();
+    MString MValue = Split2[i][1];
+    string Value = MValue.Data();
     
     if (Split2[i][0] == "emin") {
       m_EnergyMinimum = stod(Value);
@@ -185,6 +190,8 @@ bool MResponseImagingBinnedMode::ParseOptions(const MString& Options)
       m_EnergyNBins = 0;
     } else if (Split2[i][0] == "anglebinwidth") {
       m_AngleBinWidth = stod(Value);
+    } else if (Split2[i][0] == "anglebinmode") {
+      m_AngleBinMode = MValue.ToLower();
     } else if (Split2[i][0] == "dmin") {
       m_DistanceMinimum = stod(Value);
     } else if (Split2[i][0] == "dmax") {
@@ -193,6 +200,8 @@ bool MResponseImagingBinnedMode::ParseOptions(const MString& Options)
       m_DistanceNBins = stod(Value);
     } else if (Split2[i][0] == "anglebinwidthelectron") {
       m_AngleBinWidthElectron = stod(Value);
+    } else if (Split2[i][0] == "anglebinmodeelectron") {
+      m_AngleBinModeElectron = MValue.ToLower();
     } else if (Split2[i][0] == "atabsfilename") {
       m_AtmosphericAbsorptionFileName = Value;
     } else if (Split2[i][0] == "atabsaltitude") {
@@ -253,6 +262,14 @@ bool MResponseImagingBinnedMode::ParseOptions(const MString& Options)
     mout<<"Error: You need at give a positive width of the sky bins at the equator for the recoil electron"<<endl;
     return false;       
   }
+  if (m_AngleBinMode != "fisbel" && m_AngleBinMode != "healpix") {
+    mout<<"Error: Sky bins only support fisbel and healpix modes"<<endl;
+    return false;       
+  }
+  if (m_AngleBinModeElectron != "fisbel" && m_AngleBinModeElectron != "healpix") {
+    mout<<"Error: Sky bins for the recoil electron only support fisbel and healpix modes"<<endl;
+    return false;       
+  }
   if (m_AtmosphericAbsorptionFileName != "") {
     if (MFile::Exists(m_AtmosphericAbsorptionFileName) == false) {
       mout<<"Error: The file: \""<<m_AtmosphericAbsorptionFileName<<"\" does not exist"<<endl;
@@ -279,10 +296,12 @@ bool MResponseImagingBinnedMode::ParseOptions(const MString& Options)
     mout<<"  Number of bins energy:                              "<<m_EnergyNBins<<endl;
   }
   mout<<"  Width of sky bins at equator:                       "<<m_AngleBinWidth<<endl;
+  mout<<"  Sky bins binning mode:                              "<<m_AngleBinMode<<endl;
   mout<<"  Minimum distance:                                   "<<m_DistanceMinimum<<endl;
   mout<<"  Maximum distance:                                   "<<m_DistanceMaximum<<endl;
   mout<<"  Number of bins distance:                            "<<m_DistanceNBins<<endl;
   mout<<"  Width of sky bins at equator for recoild electron:  "<<m_AngleBinWidthElectron<<endl;
+  mout<<"  Binning mode for recoild electron:                  "<<m_AngleBinModeElectron<<endl;
   if (m_UseAtmosphericAbsorption == true) {
     mout<<"  Atmospheric absorption file name:                   "<<m_AtmosphericAbsorptionFileName<<endl;
     mout<<"  Atmospheric absorption altitude:                    "<<m_Altitude<<endl;
@@ -302,11 +321,6 @@ bool MResponseImagingBinnedMode::Initialize()
   // Initialize next matching event, save if necessary
   if (MResponseBuilder::Initialize() == false) return false;
 
-  int AngleBins = 4*c_Pi*c_Deg*c_Deg / m_AngleBinWidth / m_AngleBinWidth;
-  if (AngleBins < 1) AngleBins = 1;
-  int AngleBinsElectron = 4*c_Pi*c_Deg*c_Deg / m_AngleBinWidthElectron / m_AngleBinWidthElectron;
-  if (AngleBinsElectron < 1) AngleBinsElectron = 1;
-  
   MResponseMatrixAxis AxisEnergyInitial("Initial energy [keV]");
   if (m_EnergyBinEdges.size() > 0) {
     AxisEnergyInitial.SetBinEdges(m_EnergyBinEdges);
@@ -315,8 +329,13 @@ bool MResponseImagingBinnedMode::Initialize()
   }
   
   MResponseMatrixAxisSpheric AxisSkyCoordinates("#nu [deg]", "#lambda [deg]");
-  AxisSkyCoordinates.SetFISBEL(AngleBins);
 
+  if (m_AngleBinMode == "fisbel") {
+    AxisSkyCoordinates.SetFISBELSize(m_AngleBinWidth);
+  }else{
+    AxisSkyCoordinates.SetHEALPixSize(m_AngleBinWidth);
+  }
+    
   MResponseMatrixAxis AxisEnergyMeasured("Measured energy [keV]");
   if (m_EnergyBinEdges.size() > 0) {
     AxisEnergyMeasured.SetBinEdges(m_EnergyBinEdges);
@@ -328,15 +347,21 @@ bool MResponseImagingBinnedMode::Initialize()
   AxisPhi.SetLinear(180/m_AngleBinWidth, 0, 180);
   
   MResponseMatrixAxisSpheric AxisScatteredGammaRayCoordinates("#psi [deg]", "#chi [deg]");
-  AxisScatteredGammaRayCoordinates.SetFISBEL(AngleBins);
+  if (m_AngleBinMode == "fisbel") {
+    AxisScatteredGammaRayCoordinates.SetFISBELSize(m_AngleBinWidth);
+  }else{
+    AxisScatteredGammaRayCoordinates.SetHEALPixSize(m_AngleBinWidth);
+  }
   
   MResponseMatrixAxisSpheric AxisRecoilElectronCoordinates("#sigma [deg]", "#tau [deg]");
-  AxisRecoilElectronCoordinates.SetFISBEL(AngleBinsElectron);
-  
+  if (m_AngleBinModeElectron == "fisbel") {
+    AxisRecoilElectronCoordinates.SetFISBELSize(m_AngleBinWidthElectron);
+  }else{
+    AxisRecoilElectronCoordinates.SetHEALPixSize(m_AngleBinWidthElectron);
+  }
+    
   MResponseMatrixAxis AxisDistance("Distance [cm]");
   AxisDistance.SetLinear(m_DistanceNBins, m_DistanceMinimum, m_DistanceMaximum);
-  
-  
   
   m_ImagingResponse.SetName("10D imaging response");
   m_ImagingResponse.AddAxis(AxisEnergyInitial);


### PR DESCRIPTION
The imaging response mode of `responsecreator` now supports the options `anglebinmode=healpix` and `anglebinmodeelectron=healpix`. Instead of FISBEL, it will use a HEALPix grid of an appropriate order (the pixels will have an area equal or smaller than `anglebinwidth`^2 and `anglebinwidthelectron`^2, respectively). The defaults didn't change.

I created an abstract `MBinnerSpherical` class. Both `MBinnerFISBEL` and the new `MBinnerHEALPix` inherit from it. `MResponseMatrixAxisSpheric` now has a pointer to a `MBinnerSpherical` object that is initiated appropriately depending on the user inputs. 

To test run e.g. 
```
responsecreator -g sftp/ComptonSphere.geo.setup -f sftp/FlatContinuumIsotropic.inc1.id1.sim -r new -m ib -s 100 -i 100 -c sftp/Revan.cfg -b sftp/Mimrec.cfg -o anglebinmode=healpix:anglebinmodeelectron=healpix -h
```

Should result in axes like this one:
```
# Axis name
AN "#nu [deg]" "#lambda [deg]"
# Axis type
AT 2D HEALPix
# Axis data
AD 4  RING
```

`responsemanipulator` knows how to handle this axis type.

Caveats and things that might still need to change:
1.  @zoglauer you might had have something cleaner in mine for the Makefile. I added the `HEACFLAGS`/`HEALPIXCFLAGS` and `HEALIBS`/`HEALPIXLIBS` to `CXXFLAGS` and `LIBS`, respectively. I tried to just add them exactly where they are needed but other things fail to link because CommonMisc is every where. Maybe I missed something
2. Should `setup.sh` try to install healpix if it is not found? I'm actually confused about this one @zoglauer, I though you had done this already but I couldn't find where it happens.
3. There are other response types for which we would want to make this change --e.g. polarization. Let's see first if this one works though. 
