### PR TITLE
ADD : EM parameters updated

### DIFF
--- a/src/cosima/src/MCPhysicsList.cc
+++ b/src/cosima/src/MCPhysicsList.cc
@@ -58,6 +58,8 @@
 #include "G4LossTableManager.hh"  
 #include "G4NuclideTable.hh"
 
+#include "G4EmParameters.hh"
+
 // MEGAlib:
 #include "MStreams.h"
 
@@ -208,12 +210,20 @@ void MCPhysicsList::ConstructProcess()
       //cout<<P->GetProcessName()<<endl;
       if (dynamic_cast<G4RadioactiveDecay*>(P) != 0) {
         G4RadioactiveDecay* RadioactiveDecay = dynamic_cast<G4RadioactiveDecay*>(P);
-        //RadioactiveDecay->SetICM(true);  // Internal Conversion -> removed from PhysicList in v10.2 see release note
+        //RadioactiveDecay->SetICMode(true);  // Internal Conversion geant4 11  removed SetICM() method, as deprecated for some time and no longer used. ICM now set exclusively in G4PhotonEvaporation. Added printout of the flag of atomic relaxation.
         RadioactiveDecay->SetARM(true);  // Atomic Rearrangement, i.e. filling of shell vacancies
         //RadioactiveDecay->SetHLThreshold(1.0E-9*second);  // Half life cut-off of isomeric states | no longer exist in g4 v11 , no track of that on the release notes 
       }
-    }
-  }
+      
+     // if (dynamic_cast<G4ComptonScattering*>(P) != 0) {
+     //   cout<< "compton here !"<<endl;
+      
+     //   G4ComptonScattering* ComptonScat = dynamic_cast<G4ComptonScattering*>(P);
+     //    ComptonScat->SetMinKinEnergy(1*GeV);
+     // }
+      
+    } //end for loop
+  }//end while loop
   
   G4VAtomDeexcitation* D = G4LossTableManager::Instance()->AtomDeexcitation();
   D->SetFluo(true);
@@ -223,8 +233,19 @@ void MCPhysicsList::ConstructProcess()
   G4NuclideTable::GetInstance()->SetLevelTolerance(100*eV);
   G4NuclideTable::GetInstance()->SetThresholdOfHalfLife(0.0001*ns);
   
-
+  // for geant4 v11 in order to have same EM parameters as v10.02
+  G4EmParameters* emParameters = G4EmParameters::Instance();
+  emParameters->SetFluo(true);
+  emParameters->SetPixe(true);
+  emParameters->SetAuger(true);
+  emParameters->SetDeexcitationIgnoreCut(false);
   
+  //remove the comments below if you want exactly the same paramameters as v10.02
+  //Not sure of the result if you do that
+  //emParameters->SetMuHadLateralDisplacement(false);
+  //emParameters->SetMscRangeFactor(0.04);
+  //emParameters->SetMscSkin(1);
+  //emParameters->SetAugerCascade(false);
   
   /* unnecessary as of Geant4 9.6
   // Do some additional modifications to the default lists:


### PR DESCRIPTION
`SetDeexcitationIgnoreCut` was set to true for version 11 instead of false for version 10.02. Put it explicitly false on the physic list solved the issue of the factor 10 for the computation time. 

Some comments about this option : 

In Geant4 version 11, the `SetDeexcitationIgnoreCut` method is used to control the behavior of the `G4RadioactiveDecay`process during the simulation. This method sets a flag to ignore the cut imposed by the user on the production of secondary particles by radioactive decays.

By default, when a radioactive decay occurs and produces one or more secondary particles (e.g. electrons, positrons, photons), these particles are subject to the same range cut and production thresholds as any other particle in the simulation. This means that if the range of a secondary particle is smaller than the range cut or the production threshold, it may be discarded by the simulation.

However, in some cases it may be desirable to ignore these cuts for secondary particles produced by radioactive decays. This can be achieved by calling the `SetDeexcitationIgnoreCut` method with a value of true. This will cause the range cut and production thresholds to be ignored for all secondary particles produced by the `G4RadioactiveDecay` process.

It should be noted that ignoring the range cut and production thresholds can lead to longer simulation times and may affect the accuracy of the simulation. Therefore, this feature should be used with caution and only when it is necessary to model the specific physics of the problem being studied.