### PR TITLE
Add new activation option for DC5 (build-up + ActivationBuildup)

### DIFF
--- a/src/cosima/inc/MCParameterFile.hh
+++ b/src/cosima/inc/MCParameterFile.hh
@@ -156,6 +156,8 @@ public:
   static const int c_DecayModeActivationBuildUp;
   /// The decay mode delayed decay for 2-stage activation simulations
   static const int c_DecayModeActivationDelayedDecay;
+  /// The decay mode build-up + buildup for 2-stage activation simulations
+  static const int c_DecayModeBuildUpAndSaveActivation;
 
   /// Pretriggering is off
   static const int c_PreTriggerEverything;

--- a/src/cosima/src/MCParameterFile.cc
+++ b/src/cosima/src/MCParameterFile.cc
@@ -43,6 +43,7 @@ const int MCParameterFile::c_DecayModeIgnore                  = 1;
 const int MCParameterFile::c_DecayModeBuildUp                 = 2;
 const int MCParameterFile::c_DecayModeActivationBuildUp       = 3;
 const int MCParameterFile::c_DecayModeActivationDelayedDecay  = 4;
+const int MCParameterFile::c_DecayModeBuildUpAndSaveActivation = 5;
 
 const int MCParameterFile::c_PreTriggerEverything             = 0;
 const int MCParameterFile::c_PreTriggerEveryEventWithHits     = 1;
@@ -320,6 +321,8 @@ bool MCParameterFile::Parse()
           m_DecayMode = c_DecayModeNormal;
         } else if  (Mode == "buildup" || Mode == "build-up") {
           m_DecayMode = c_DecayModeBuildUp;  
+        } else if  (Mode == "buildupandsave") {
+          m_DecayMode = c_DecayModeBuildUpAndSaveActivation;  
         } else if  (Mode == "ignore") {
           m_DecayMode = c_DecayModeIgnore;  
         } else if  (Mode == "activationbuildup") {

--- a/src/cosima/src/MCSteppingAction.cc
+++ b/src/cosima/src/MCSteppingAction.cc
@@ -912,7 +912,30 @@ void MCSteppingAction::UserSteppingAction(const G4Step* Step)
               DoNotStart = true;
             }
           }
-        }
+        } else if (m_DecayMode == MCParameterFile::c_DecayModeBuildUpAndSaveActivation) {
+	  if (IsInitialParticleFromBuildUpSource == true) {
+            // Simulate primaries now:
+            Keep = true;
+            Store = false;
+            FutureEvent = false;
+            DoNotStart = false;
+          } else {
+            // Delay secondary decays to the future:
+            if (TimeDelay > m_DetectorTimeConstant) {
+              Keep = false;
+              Store = true;
+              FutureEvent = true;
+              DoNotStart = false;
+            } else {
+              Keep = true;
+              Store = false;
+              FutureEvent = false;
+              DoNotStart = false;
+            }
+          }
+	
+	
+	}
         //cout<<"  P:"<<int(IsPrimaryDecay)<<"  K:"<<int(Keep)<<"  S:"<<int(Store)<<"  F:"<<int(FutureEvent)<<endl;
         //cout<<"Handling: "<<dynamic_cast<G4Ions*>(Track->GetDefinition())->GetParticleName()<<endl;
         


### PR DESCRIPTION
I added a new option `buildupandsave` for the activation which is just the merging of `ActivationBuildup` and `Buildup`.

With this option the isotopes with lifetime > DetectorTimeConstant are keep in memory until they decay AND saved in the isotope file.

This will allow us to make only one simulation to test both buildup and 3 steps method for DC5. 

Typical example :
```
Version                            1
Geometry                           Ge.geo.setup
DetectorTimeConstant               0.000005
 
PhysicsListHD                      qgsp-bic-hp
PhysicsListEM                      LivermorePol
DecayMode                          buildupandsave
 
StoreCalibrated                    true
StoreSimulationInfo                true
DiscretizeHits                     true
 
Run SpaceSim
SpaceSim.FileName                  Ge_Buildup_proton
SpaceSim.IsotopeProductionFile     Ge_Isotopes
SpaceSim.Time                      360

Include CosmicProtonsSpenvis.partial.source

```
