### PR TITLE
Guard warning `MDGeometry::GetVolumeSequencePointer` by `c_Warning`

### DIFF
--- a/src/geomega/src/MDGeometry.cxx
+++ b/src/geomega/src/MDGeometry.cxx
@@ -5846,7 +5846,9 @@ MDVolumeSequence* MDGeometry::GetVolumeSequencePointer(MVector Pos, bool ForceDe
     out<<"     --> No suitable volume found!"<<endl;
 
     // Only print the warning if we did not find anything
-    cout<<out.str()<<endl; // cout instead of mout...
+    if (g_Verbosity >= c_Warning) {
+      cout<<out.str()<<endl; // cout instead of mout...
+    }
   }
 
   return VS;


### PR DESCRIPTION
Related to https://github.com/cositools/nuclearizer/issues/109:

There is a very lengthy warning in cosima that is printed in case that hits cannot be associated with any detector volume:
```
Warning:
No detector volume could be found for the hit at position -9.7443299999999997141, 1.0029300000000000992, 3.5640999999999998238
The deepest volume is: Cryostat_Interior
Possible reasons are:
* The hit is just (+-1e-06 cm) outside the border of the volume:
-> Make sure you have stored your simulation file with enough digits
(cosima keyword "StoreScientific") so that the volume borders can be separated
-> Make sure your search tolerance given in the geometry file (geomega keyword
"DetectorSearchTolerance") is not too small
* The current and the simulation geometry are not identical
* There are overlaps in your geometry:
-> No simple overlaps found, but you might do a full overlap check anyway...
Searching for a detector within 1e-06 cm around the given position...
--> No suitable volume found!

This hit at (-9.74433, 1.00293, 3.5641) has no corresponding detector volume!
--> It will not show up in the later analysis!
```
Can we make that warning guarded by `c_Warning`, so that the user can have the option of omitting those warnings?
With this PR, the terminal would only print the very last part:
```
This hit at (-9.74433, 1.00293, 3.5641) has no corresponding detector volume!
--> It will not show up in the later analysis!
```