### PR TITLE
CHG: Updates to `MTime` - Interpret times in UTC instead of local time

### DIFF
--- a/src/global/misc/inc/MTime.h
+++ b/src/global/misc/inc/MTime.h
@@ -28,24 +28,25 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
-
+//! A time class with nanosecond precision relative to the Unix epoch
 class MTime
 {
   // public interface:
  public:
   //! Default constructor, set the time to 0
   MTime();
-  //! Extracts the time from a string -- deprecated! -- don't use since there vis no error catching done! 
-  explicit MTime(MString SQLString, int Format);
+  //! Extract the time from a formatted string
+  //! Deprecated: this parser has limited error handling
+  explicit MTime(MString String, int Format);
   //! Set the time as two long integers -- the time is counted since Epoch
   MTime(long int LinuxTime, long int NanoSeconds = 0);
-  //! Set the time as two intergers -- the time is counted since Epoch
+  //! Set the time as two integers -- the time is counted since Epoch
   MTime(int LinuxTime, int NanoSeconds = 0);
   //! Set the time as two unsigned integers -- the time is counted since Epoch
   MTime(unsigned int LinuxTime, unsigned int NanoSeconds = 0);
   //! Set the time elements (years, days, etc) individually
-  MTime(unsigned int m_Year, unsigned int m_Month, unsigned int m_Day, unsigned int m_Hour = 0, 
-        unsigned int m_Minute = 0, unsigned int m_Second = 0, unsigned int m_NanoSecond = 0);
+  MTime(unsigned int Year, unsigned int Month, unsigned int Day, unsigned int Hour = 0,
+        unsigned int Minute = 0, unsigned int Second = 0, unsigned int NanoSecond = 0);
   //! Set the time as a double -- the time is counted since Epoch
   MTime(double Time);
   //! Copy constructor
@@ -57,14 +58,22 @@ class MTime
 
   // TODO: Some of these function return false by default! Before next alpha release switch it!
   
+  //! Set the time to the current system time
   bool Now();
-  bool Set(unsigned int m_Year, unsigned int m_Month, unsigned int m_Day, unsigned int m_Hour = 0, 
-             unsigned int m_Minute = 0, unsigned int m_Second = 0, unsigned int m_NanoSecond = 0);
+  //! Set the time from calendar fields
+  bool Set(unsigned int Year, unsigned int Month, unsigned int Day, unsigned int Hour = 0,
+           unsigned int Minute = 0, unsigned int Second = 0, unsigned int NanoSecond = 0);
+  //! Set the time from seconds and nanoseconds since the epoch
   bool Set(const long int LinuxTime, const long int NanoSeconds = 0);
+  //! Set the time from seconds and nanoseconds since the epoch
   bool Set(const int LinuxTime, const int NanoSeconds = 0);
+  //! Set the time from seconds and nanoseconds since the epoch
   bool Set(const unsigned int LinuxTime, const unsigned int NanoSeconds = 0);
+  //! Set the time from separate seconds and nanoseconds given as doubles
   bool Set(const double Seconds, const double NanoSeconds);
+  //! Set the time from seconds since the epoch
   bool Set(double Time);
+  //! Set the time from another MTime instance
   bool Set(const MTime& Time);
   //! Set a string in MEGAlib TI format: TI 123456789.123456789
   //! Starts the conversion at character I
@@ -95,55 +104,64 @@ class MTime
   //! Get the years in the time
   unsigned int GetYears();
 
-
-  // The operators
-  
+  //! Assignment operator
   MTime& operator=(const MTime& Time);
-  MTime& operator*=(const double& Const);
+  //! Scale the time by a constant in place
+  MTime& operator*=(const double& Constant);
+  //! Add another time in place
   MTime& operator+=(const MTime& Time);
+  //! Subtract another time in place
   MTime& operator-=(const MTime& Time);
+  //! Return the sum of two times
   MTime operator+(const MTime& Time);
+  //! Return the difference of two times
   MTime operator-(const MTime& Time);
-  MTime operator*(const double& v);
-  MTime operator/(const double& v);
+  //! Return the time scaled by a constant
+  MTime operator*(const double& Value);
+  //! Return the time divided by a constant
+  MTime operator/(const double& Value);
+  //! Return true if two times differ
   bool operator!=(const MTime& Time) const;
+  //! Return true if two times are identical
   bool operator==(const MTime& Time) const;
+  //! Return true if this time is later than or equal to Time
   bool operator>=(const MTime& Time) const;
+  //! Return true if this time is earlier than or equal to Time
   bool operator<=(const MTime& Time) const;
+  //! Return true if this time is later than Time
   bool operator>(const MTime& Time) const;
+  //! Return true if this time is earlier than Time
   bool operator<(const MTime& Time) const;
 
   
-  // Conversions
-
-  // Convert into a double 
+  //! Convert the time into seconds since the epoch as a double
   double GetAsDouble() const;
   //! Return the days since the epoch 1970-01-01
   unsigned int GetDaysSinceEpoch();
   //! Get the seconds since epoch in double format (should be renamed: GetSecondsSinceEpoch())
   double GetAsSeconds() const;
-  //! Get as years in the form 2008.45345 
+  //! Get the time as a fractional year, e.g. 2008.45345
   double GetAsYears();
   //! Return the seconds since epoch
   long int GetAsSystemSeconds();
   //! Convert into Julian days
   double GetAsJulianDay();
 
-  // Return in Format: 76751347.238477
+  //! Return as a human-readable "Seconds since epoch" string
   MString GetString();
-  // Return in Format: 15.05.2002 13:15:23:123456789
+  //! Return in format: 15.05.2002 13:15:23:123456789
   MString GetUTCString();
-  // Return in Format: 1997-01-15 20:16:28
+  //! Return in format: 1997-01-15 20:16:28
   MString GetSQLString();
-  // Return in Format: 1997-01-15_20:16:28
+  //! Return in format: 1997-01-15_20:16:28
   MString GetSQLUString();
-  // Return in Format: 19970115_201628
+  //! Return in format: 19970115_201628
   MString GetShortString();
-  // Return in Format: 1164864276.623883519
+  //! Return in format: 1164864276.623883519
   MString GetLongIntsString() const;
-  // Return as fits date string: 31/12/94
+  //! Return as FITS date string: 31/12/94
   MString GetFitsDateString();
-  // Return as fits time string: 15:45:57
+  //! Return as FITS time string: 15:45:57
   MString GetFitsTimeString();
   
   
@@ -155,9 +173,8 @@ class MTime
 
   enum Format { FormatLowerLimit = 0, Short, UTC, SQL, SQLU, LongInts, MEGAlib, FormatUpperLimit };
 
-
-  // protected methods:
- protected:
+protected:
+  //! Normalize the seconds and nanoseconds representation
   void Normalize();
 
   // private methods:
@@ -170,9 +187,11 @@ class MTime
 
 
   // private members:
- private:
+private:
+  //! Seconds since the Unix epoch
   long int m_Seconds;
-  long int m_NanoSeconds; 
+  //! Nanoseconds relative to m_Seconds
+  long int m_NanoSeconds;
 
 
 #ifdef ___CLING___
@@ -182,6 +201,7 @@ class MTime
 
 };
 
+//! Stream a time to an output stream
 std::ostream& operator<<(std::ostream& os, const MTime& Time);
 
 

--- a/src/global/misc/src/MTime.cxx
+++ b/src/global/misc/src/MTime.cxx
@@ -18,9 +18,9 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 //
-// MTime in nanosecond precision - if supported by system 
+// MTime in nanosecond precision - if supported by system
 //
-// This class is able to represent a time span and a calender time, depending
+// This class is able to represent a time span and a calendar time, depending
 // on the construction and executed operation
 //
 // Examples:
@@ -220,7 +220,7 @@ MTime::~MTime()
 bool MTime::Now()
 {
   // Set the value to the current time
-  // The behaviour is encapsulted into the MSystem class, due to differneces
+  // The behaviour is encapsulated into the MSystem class, due to differences
   // between Windows and Linux
 
   MSystem::GetTime(m_Seconds, m_NanoSeconds);
@@ -344,10 +344,10 @@ bool MTime::Set(const unsigned int Seconds, const unsigned int NanoSeconds)
 
 bool MTime::Set(const double Seconds, const double NanoSeconds)
 {
-  //
+  // Set the time from two double values representing seconds and nanoseconds
 
   Set(Seconds);
-  MTime Temp(NanoSeconds/1000000000);
+  MTime Temp(NanoSeconds / 1000000000);
   *this += Temp;
 
   return false;
@@ -376,7 +376,7 @@ bool MTime::Set(double Time)
 bool MTime::Set(const char* Line)
 {
   // This is the fast, unsafe, no-error checks version:
-  // If you want it save use the MString version
+  // If you want it safe use the MString version
 
   char* Text = strdup(Line);
   size_t Size = strlen(Text);
@@ -392,7 +392,7 @@ bool MTime::Set(const char* Line)
 
     while (Stop < Size && isdigit(Text[Stop])) ++Stop;
     if (Stop < Size) Text[Stop] = '\0';
-    m_Seconds = atoi(Text+Start);
+    m_Seconds = atoi(Text + Start);
     if (m_Seconds == numeric_limits<int>::max()) {
       mout<<"Seconds in MTime are maxed out... time is probably wrong: "<<Line<<endl;
     }
@@ -409,8 +409,8 @@ bool MTime::Set(const char* Line)
       // Count digits:
       int Digits = Stop - Start;
       if (Digits > 9) Digits = 9;
-      Text[Start+Digits] = '\0';
-      m_NanoSeconds = atoi(Text+Start);
+      Text[Start + Digits] = '\0';
+      m_NanoSeconds = atoi(Text + Start);
       if (Digits < 9) {
         m_NanoSeconds *= int(pow(10.0, 9.0 - Digits));
       } else if (Digits > 9) {
@@ -445,7 +445,7 @@ bool MTime::Set(const MString& String, unsigned int I)
     return false;
   }
   
-  // Split and 
+  // Split the value into seconds and fractional seconds
   MTokenizer T('.', true);
   T.Analyze(NewString);
   if (T.GetNTokens() == 1) {
@@ -501,7 +501,7 @@ void MTime::Normalize()
 
 double MTime::GetElapsedSeconds()
 {
-  // Return the number of seconds which are ellapsed since MTime
+  // Return the number of seconds which are elapsed since MTime
 
   MTime Now;
 
@@ -514,7 +514,7 @@ double MTime::GetElapsedSeconds()
 
 unsigned int MTime::GetNanoSeconds()
 {
-  // Return the seconds
+  // Return the nanoseconds
 
   return m_NanoSeconds;
 }
@@ -585,8 +585,8 @@ unsigned int MTime::GetDaysSinceEpoch()
   while (Year > 1970) {
     Year--;
     MTime NewTime(Year, 12, 31, 23, 59, 30);
-    time_t Seconds = (long int) NewTime.GetAsSeconds();
-    tp = *gmtime(&Seconds);
+    time_t LastSecondOfYear = (long int) NewTime.GetAsSeconds();
+    tp = *gmtime(&LastSecondOfYear);
     Days += tp.tm_yday;
   }
 
@@ -696,11 +696,15 @@ double MTime::GetAsJulianDay()
   int Second = tp.tm_sec;
   int NanoSecond = m_NanoSeconds;
 
-  double JDDay, JDFraction;
+  double JDDay;
+  double JDFraction;
 
   // Now transform to julian day:
   bool reform;
-  long a, b=0, c, d;
+  long a;
+  long b = 0;
+  long c;
+  long d;
   double x1;
 
   if (Month < 3) {
@@ -755,7 +759,7 @@ MString MTime::GetString()
 {
   // Return in Format: 76751347.238477
 
-  const int Length= 100;
+  const int Length = 100;
   char Text[Length];
   double Time = GetAsSeconds();
   snprintf(Text, Length, "Seconds since epoch: %10.6f", Time);
@@ -775,7 +779,7 @@ MString MTime::GetLongIntsString() const
   int Precision = 9;
   
   long Nanos = m_NanoSeconds;
-  Nanos /= (long) pow(10.0, 9-Precision);
+  Nanos /= (long) pow(10.0, 9 - Precision);
   
   ostringstream out;
   out<<((Nanos < 0 && m_Seconds == 0) ? "-" : "")<<m_Seconds;
@@ -922,13 +926,13 @@ MTime& MTime::operator+=(const MTime& T)
 ////////////////////////////////////////////////////////////////////////////////
 
 
-MTime& MTime::operator*=(const double& T)
+MTime& MTime::operator*=(const double& Constant)
 {
-  if (numeric_limits<long>::max() < double(m_NanoSeconds)*T) {
+  if (numeric_limits<long>::max() < double(m_NanoSeconds) * Constant) {
     merr<<"Overflow in MTime..."<<endl;
-  } 
+  }
   
-  Set(m_Seconds*T, m_NanoSeconds*T);
+  Set(m_Seconds * Constant, m_NanoSeconds * Constant);
   return *this;
 }
 
@@ -955,14 +959,14 @@ MTime MTime::operator+(const MTime& T)
 ////////////////////////////////////////////////////////////////////////////////
 
 
-MTime MTime::operator*(const double& v)
+MTime MTime::operator*(const double& Value)
 {
-  if (numeric_limits<long>::max() < double(m_NanoSeconds)*v) {
+  if (numeric_limits<long>::max() < double(m_NanoSeconds) * Value) {
     merr<<"Overflow in MTime..."<<endl;
-  } 
+  }
   
   MTime Time;
-  Time.Set(m_Seconds*v, m_NanoSeconds*v);
+  Time.Set(m_Seconds * Value, m_NanoSeconds * Value);
 
   return Time;
 }
@@ -970,10 +974,10 @@ MTime MTime::operator*(const double& v)
 ////////////////////////////////////////////////////////////////////////////////
 
 
-MTime MTime::operator/(const double& v)
+MTime MTime::operator/(const double& Value)
 {
   MTime Time;
-  Time.Set(double(m_Seconds)/v, double(m_NanoSeconds)/v);
+  Time.Set(double(m_Seconds) / Value, double(m_NanoSeconds) / Value);
   
   return Time;
 }

--- a/src/global/misc/src/MTime.cxx
+++ b/src/global/misc/src/MTime.cxx
@@ -98,22 +98,22 @@ MTime::MTime(MString String, int Format)
 
   switch (Format) {
   case UTC:
-    Result = sscanf(String, "%02u.%02u.%04d %02u:%02u:%02u:%09u", 
-        &Years, &Months, &Days, &Hours, &Minutes, &Seconds, &NanoSeconds);
-    if (Result != 6) Result = -1; // Means: we have an error
+    Result = sscanf(String, "%02d.%02d.%04d %02d:%02d:%02d:%09d",
+        &Days, &Months, &Years, &Hours, &Minutes, &Seconds, &NanoSeconds);
+    if (Result != 7) Result = -1; // Means: we have an error
     break;
   case SQL:
-    Result = sscanf(String, "%04d-%02u-%02u %02u:%02u:%02u", 
+    Result = sscanf(String, "%04d-%02d-%02d %02d:%02d:%02d",
         &Years, &Months, &Days, &Hours, &Minutes, &Seconds);
     if (Result != 6) Result = -1; // Means: we have an error
     break;
   case SQLU:
-    Result = sscanf(String, "%04d-%02u-%02u_%02u:%02u:%02u", 
+    Result = sscanf(String, "%04d-%02d-%02d_%02d:%02d:%02d",
         &Years, &Months, &Days, &Hours, &Minutes, &Seconds);
     if (Result != 6) Result = -1; // Means: we have an error
     break;
   case Short:
-    Result = sscanf(String, "%04d%02u%02u_%02u%02u%02u", 
+    Result = sscanf(String, "%04d%02d%02d_%02d%02d%02d",
         &Years, &Months, &Days, &Hours, &Minutes, &Seconds);
     if (Result != 6) Result = -1; // Means: we have an error
     break;
@@ -248,7 +248,7 @@ bool MTime::Set(unsigned int Year, unsigned int Month, unsigned int Day,
   struct tm tp;
 
   if (Year < 70) Year += 100;
-  if (Year > 1970) Year -= 1900;
+  if (Year >= 1970) Year -= 1900;
   tp.tm_year = Year;
   if (Month <= 0) {
     tp.tm_yday = Day;
@@ -261,7 +261,7 @@ bool MTime::Set(unsigned int Year, unsigned int Month, unsigned int Day,
   tp.tm_sec = Second;
   tp.tm_isdst = 0; // GMT: no daylight savings!
 
-  m_Seconds = mktime(&tp);
+  m_Seconds = timegm(&tp);
 
   if (m_Seconds == -1) {
     merr<<"Invalid time!!"<<endl;
@@ -529,7 +529,7 @@ unsigned int MTime::GetSeconds()
 
   time_t Time = m_Seconds;
   struct tm tp;
-  tp = *localtime(&Time);
+  tp = *gmtime(&Time);
 
   return tp.tm_sec;
 }
@@ -544,7 +544,7 @@ unsigned int MTime::GetMinutes()
 
   time_t Time = m_Seconds;
   struct tm tp;
-  tp = *localtime(&Time);
+  tp = *gmtime(&Time);
 
   return tp.tm_min;
 }
@@ -559,7 +559,7 @@ unsigned int MTime::GetHours()
 
   time_t Time = m_Seconds;
   struct tm tp;
-  tp = *localtime(&Time);
+  tp = *gmtime(&Time);
 
   return tp.tm_hour;
 }
@@ -577,7 +577,7 @@ unsigned int MTime::GetDaysSinceEpoch()
 
   time_t Time = m_Seconds;
   struct tm tp;
-  tp = *localtime(&Time);
+  tp = *gmtime(&Time);
 
   unsigned int Days = tp.tm_yday;
 
@@ -586,7 +586,7 @@ unsigned int MTime::GetDaysSinceEpoch()
     Year--;
     MTime NewTime(Year, 12, 31, 23, 59, 30);
     time_t Seconds = (long int) NewTime.GetAsSeconds();
-    tp = *localtime(&Seconds);
+    tp = *gmtime(&Seconds);
     Days += tp.tm_yday;
   }
 
@@ -603,7 +603,7 @@ unsigned int MTime::GetDays()
 
   time_t Time = m_Seconds;
   struct tm tp;
-  tp = *localtime(&Time);
+  tp = *gmtime(&Time);
 
   return tp.tm_mday;
 }
@@ -617,7 +617,7 @@ unsigned int MTime::GetMonths()
 
   time_t Time = m_Seconds;
   struct tm tp;
-  tp = *localtime(&Time);
+  tp = *gmtime(&Time);
 
   return tp.tm_mon+1;
 }
@@ -632,7 +632,7 @@ unsigned int MTime::GetYears()
 
   time_t Time = m_Seconds;
   struct tm tp;
-  tp = *localtime(&Time);
+  tp = *gmtime(&Time);
 
   return tp.tm_year+1900;
 }
@@ -686,7 +686,7 @@ double MTime::GetAsJulianDay()
 
   time_t Time = m_Seconds;
   struct tm tp;
-  tp = *localtime(&Time);
+  tp = *gmtime(&Time);
 
   int Year = tp.tm_year+1900;
   int Month = tp.tm_mon+1;
@@ -993,7 +993,7 @@ MTime MTime::operator-(const MTime& T)
 
 bool MTime::operator!=(const MTime& T) const
 {
-  return ((m_Seconds != T.m_Seconds) && (m_NanoSeconds != T.m_NanoSeconds));
+  return ((m_Seconds != T.m_Seconds) || (m_NanoSeconds != T.m_NanoSeconds));
 }
 
 

--- a/src/global/misc/unittests/UTTime.cxx
+++ b/src/global/misc/unittests/UTTime.cxx
@@ -1,0 +1,347 @@
+/*
+ * UTTime.cxx
+ *
+ * Copyright (C) by Andreas Zoglauer.
+ * All rights reserved.
+ *
+ * Please see the source-file for the copyright-notice.
+ *
+ */
+
+
+// MEGAlib:
+#include "MTime.h"
+#include "MUnitTest.h"
+#include "MStreams.h"
+
+// Standard lib:
+#include <sstream>
+using namespace std;
+
+
+//! Unit test class for the MTime helper
+class UTTime : public MUnitTest
+{
+public:
+  //! Default constructor
+  UTTime() : MUnitTest("UTTime") {}
+  //! Default destructor
+  virtual ~UTTime() {}
+
+  //! Run all tests
+  virtual bool Run();
+
+private:
+  //! Test construction and direct setters
+  bool TestConstructionAndSetters();
+  //! Test normalization and arithmetic
+  bool TestArithmeticAndNormalization();
+  //! Test comparisons and scalar operators
+  bool TestComparisonsAndScaling();
+  //! Test string parsing and formatting
+  bool TestParsingAndFormatting();
+  //! Test calendar and conversion helpers
+  bool TestCalendarAndConversions();
+};
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+//! Run all tests
+bool UTTime::Run()
+{
+  bool AllPassed = true;
+
+  AllPassed = TestConstructionAndSetters() && AllPassed;
+  AllPassed = TestArithmeticAndNormalization() && AllPassed;
+  AllPassed = TestComparisonsAndScaling() && AllPassed;
+  AllPassed = TestParsingAndFormatting() && AllPassed;
+  AllPassed = TestCalendarAndConversions() && AllPassed;
+
+  Summarize();
+
+  return AllPassed;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+//! Test construction and direct setters
+bool UTTime::TestConstructionAndSetters()
+{
+  bool Passed = true;
+
+  MTime EpochLong(0L, 0L);
+  Passed = EvaluateNear("MTime(long, long)", "epoch seconds", "The long constructor stores the seconds component", EpochLong.GetAsSeconds(), 0.0, 1e-12) && Passed;
+  Passed = EvaluateNear("GetInternalNanoSeconds()", "epoch nanoseconds", "The long constructor stores the nanoseconds component", EpochLong.GetInternalNanoSeconds(), 0.0, 1e-12) && Passed;
+
+  MTime EpochInt(0, 500000000);
+  Passed = EvaluateNear("MTime(int, int)", "half second", "The int constructor stores the given nanoseconds", EpochInt.GetAsSeconds(), 0.5, 1e-12) && Passed;
+
+  MTime EpochUnsigned(1U, 250000000U);
+  Passed = EvaluateNear("MTime(unsigned int, unsigned int)", "one and a quarter seconds", "The unsigned constructor stores the given values", EpochUnsigned.GetAsSeconds(), 1.25, 1e-12) && Passed;
+
+  MTime FromDouble(12.75);
+  Passed = EvaluateNear("MTime(double)", "12.75", "The double constructor splits seconds and nanoseconds correctly", FromDouble.GetAsSeconds(), 12.75, 1e-12) && Passed;
+  Passed = EvaluateTrue("GetLongIntsString()", "12.75", "The double constructor stores the expected nanosecond precision",
+                        FromDouble.GetLongIntsString() == "12.750000000") && Passed;
+
+  MTime Calendar(1970, 1, 1, 0, 0, 0, 123456789);
+  Passed = EvaluateNear("MTime(year, month, day, ...)", "epoch calendar", "The calendar constructor builds the expected epoch time", Calendar.GetAsSeconds(), 0.123456789, 1e-12) && Passed;
+  Passed = EvaluateTrue("GetUTCString()", "epoch calendar", "The calendar constructor exposes the expected UTC string",
+                        Calendar.GetUTCString() == "01.01.1970 00:00:00:123456789") && Passed;
+
+  MTime Copy(Calendar);
+  Passed = EvaluateTrue("MTime(const MTime&)", "copy", "Copy construction preserves the stored time", Copy == Calendar) && Passed;
+
+  MTime Assigned(5L, 6L);
+  Assigned = Calendar;
+  Passed = EvaluateTrue("operator=", "assignment", "Assignment preserves the stored time", Assigned == Calendar) && Passed;
+
+  MTime SetByTime;
+  Passed = EvaluateFalse("Set(const MTime&)", "return value", "Set(const MTime&) currently returns false even though it updates the time", SetByTime.Set(Calendar)) && Passed;
+  Passed = EvaluateTrue("Set(const MTime&)", "state update", "Set(const MTime&) copies the source time", SetByTime == Calendar) && Passed;
+
+  MTime SetByLong;
+  Passed = EvaluateFalse("Set(long, long)", "return value", "Set(long, long) currently returns false after updating the time", SetByLong.Set(3L, 400000000L)) && Passed;
+  Passed = EvaluateNear("Set(long, long)", "state update", "Set(long, long) stores the given values", SetByLong.GetAsSeconds(), 3.4, 1e-12) && Passed;
+
+  MTime SetByInt;
+  Passed = EvaluateFalse("Set(int, int)", "return value", "Set(int, int) currently returns false after updating the time", SetByInt.Set(4, 500000000)) && Passed;
+  Passed = EvaluateNear("Set(int, int)", "state update", "Set(int, int) stores the given values", SetByInt.GetAsSeconds(), 4.5, 1e-12) && Passed;
+
+  MTime SetByUnsigned;
+  Passed = EvaluateFalse("Set(unsigned int, unsigned int)", "return value", "Set(unsigned int, unsigned int) currently returns false after updating the time", SetByUnsigned.Set(5U, 600000000U)) && Passed;
+  Passed = EvaluateNear("Set(unsigned int, unsigned int)", "state update", "Set(unsigned int, unsigned int) stores the given values", SetByUnsigned.GetAsSeconds(), 5.6, 1e-12) && Passed;
+
+  MTime SetByDouble;
+  Passed = EvaluateTrue("Set(double)", "return value", "Set(double) reports success", SetByDouble.Set(8.125)) && Passed;
+  Passed = EvaluateNear("Set(double)", "state update", "Set(double) stores the given time", SetByDouble.GetAsSeconds(), 8.125, 1e-12) && Passed;
+
+  MTime SetByDoubleParts;
+  Passed = EvaluateFalse("Set(double, double)", "return value", "Set(double, double) currently returns false after updating the time", SetByDoubleParts.Set(1.0, 500000000.0)) && Passed;
+  Passed = EvaluateNear("Set(double, double)", "state update", "Set(double, double) combines the two parts into one time", SetByDoubleParts.GetAsSeconds(), 1.5, 1e-12) && Passed;
+
+  return Passed;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+//! Test normalization and arithmetic
+bool UTTime::TestArithmeticAndNormalization()
+{
+  bool Passed = true;
+
+  MTime Carry(1L, 1500000000L);
+  Passed = EvaluateTrue("Normalize()", "positive carry", "Nanoseconds above one second are normalized into the seconds field",
+                        Carry.GetLongIntsString() == "2.500000000") && Passed;
+
+  MTime Borrow(1L, -500000000L);
+  Passed = EvaluateTrue("Normalize()", "positive seconds, negative nanos", "Mixed-sign representations are normalized for positive seconds",
+                        Borrow.GetLongIntsString() == "0.500000000") && Passed;
+
+  MTime NegativeCarry(-1L, -1500000000L);
+  Passed = EvaluateTrue("Normalize()", "negative carry", "Large negative nanoseconds are normalized into the seconds field",
+                        NegativeCarry.GetLongIntsString() == "-2.500000000") && Passed;
+
+  MTime NegativeBorrow(-1L, 500000000L);
+  Passed = EvaluateTrue("Normalize()", "negative seconds, positive nanos", "Mixed-sign representations are normalized into the historical negative-fraction format",
+                        NegativeBorrow.GetLongIntsString() == "-0.500000000") && Passed;
+
+  MTime Sum = MTime(1L, 750000000L) + MTime(2L, 500000000L);
+  Passed = EvaluateTrue("operator+", "sum", "operator+ adds and normalizes seconds and nanoseconds", Sum.GetLongIntsString() == "4.250000000") && Passed;
+
+  MTime Difference = MTime(5L, 250000000L) - MTime(2L, 500000000L);
+  Passed = EvaluateTrue("operator-", "difference", "operator- subtracts and normalizes seconds and nanoseconds", Difference.GetLongIntsString() == "2.750000000") && Passed;
+
+  MTime InPlaceSum(1L, 750000000L);
+  InPlaceSum += MTime(2L, 500000000L);
+  Passed = EvaluateTrue("operator+=", "sum", "operator+= matches operator+", InPlaceSum == Sum) && Passed;
+
+  MTime InPlaceDifference(5L, 250000000L);
+  InPlaceDifference -= MTime(2L, 500000000L);
+  Passed = EvaluateTrue("operator-=", "difference", "operator-= matches operator-", InPlaceDifference == Difference) && Passed;
+
+  return Passed;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+//! Test comparisons and scalar operators
+bool UTTime::TestComparisonsAndScaling()
+{
+  bool Passed = true;
+
+  MTime A(1L, 250000000L);
+  MTime B(2L, 0L);
+  MTime C(1L, 250000000L);
+  MTime D(1L, 500000000L);
+
+  Passed = EvaluateTrue("operator==", "equal", "operator== recognizes identical times", A == C) && Passed;
+  Passed = EvaluateFalse("operator!=", "equal", "operator!= is false for identical times", A != C) && Passed;
+  Passed = EvaluateTrue("operator!=", "different nanos", "operator!= is true when the nanoseconds differ", A != D) && Passed;
+  Passed = EvaluateTrue("operator<", "ordering", "operator< compares seconds before nanoseconds", A < B) && Passed;
+  Passed = EvaluateTrue("operator>", "ordering", "operator> compares seconds before nanoseconds", B > A) && Passed;
+  Passed = EvaluateTrue("operator<=", "equal", "operator<= accepts equality", A <= C) && Passed;
+  Passed = EvaluateTrue("operator>=", "equal", "operator>= accepts equality", A >= C) && Passed;
+
+  MTime Scaled = A * 2.0;
+  Passed = EvaluateTrue("operator*", "scale by 2", "operator* scales the stored time", Scaled.GetLongIntsString() == "2.500000000") && Passed;
+
+  MTime InPlaceScaled = A;
+  InPlaceScaled *= 2.0;
+  Passed = EvaluateTrue("operator*=", "scale by 2", "operator*= matches operator*", InPlaceScaled == Scaled) && Passed;
+
+  MTime Divided = MTime(5L, 0L) / 2.0;
+  Passed = EvaluateTrue("operator/", "divide by 2", "operator/ divides the stored time", Divided.GetLongIntsString() == "2.500000000") && Passed;
+
+  return Passed;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+//! Test string parsing and formatting
+bool UTTime::TestParsingAndFormatting()
+{
+  bool Passed = true;
+
+  MTime FromString;
+  Passed = EvaluateTrue("Set(MString)", "plain TI format", "Set(MString) parses the standard TI format",
+                        FromString.Set("TI 12.3456789")) && Passed;
+  Passed = EvaluateTrue("GetLongIntsString()", "plain TI format", "Set(MString) pads fractional digits to nanoseconds",
+                        FromString.GetLongIntsString() == "12.345678900") && Passed;
+
+  Passed = EvaluateTrue("Set(MString)", "with sec suffix", "Set(MString) ignores the optional sec suffix",
+                        FromString.Set("TI 7.25 sec")) && Passed;
+  Passed = EvaluateTrue("GetLongIntsString()", "with sec suffix", "Set(MString) stores the parsed seconds and nanoseconds",
+                        FromString.GetLongIntsString() == "7.250000000") && Passed;
+
+  mout.Enable(false);
+  Passed = EvaluateFalse("Set(MString)", "not a number", "Set(MString) rejects invalid input", FromString.Set(MString("TI nonsense"))) && Passed;
+  Passed = EvaluateFalse("Set(MString)", "too many separators", "Set(MString) rejects more than one fractional separator", FromString.Set(MString("1.2.3"))) && Passed;
+  mout.Enable(true);
+
+  MTime FromChar;
+  Passed = EvaluateTrue("Set(const char*)", "plain digits", "Set(const char*) parses seconds and fractional digits", FromChar.Set("TI 9.5")) && Passed;
+  Passed = EvaluateTrue("GetLongIntsString()", "plain digits", "Set(const char*) pads fractional digits to nanoseconds",
+                        FromChar.GetLongIntsString() == "9.500000000") && Passed;
+
+  Passed = EvaluateTrue("Set(const char*)", "no fractional part", "Set(const char*) accepts integer-only values", FromChar.Set("TI 11")) && Passed;
+  Passed = EvaluateTrue("GetLongIntsString()", "no fractional part", "Set(const char*) sets the nanoseconds field to zero when omitted",
+                        FromChar.GetLongIntsString() == "11.000000000") && Passed;
+
+  MTime NoDigits;
+  Passed = EvaluateTrue("Set(const char*)", "no digits", "Set(const char*) accepts digit-free input and resets to zero", NoDigits.Set("invalid")) && Passed;
+  Passed = EvaluateTrue("GetLongIntsString()", "no digits", "Set(const char*) resets to the epoch when no digits are present",
+                        NoDigits.GetLongIntsString() == "0.000000000") && Passed;
+
+  MTime UTC("01.01.1970 00:00:00:000000123", MTime::UTC);
+  Passed = EvaluateTrue("MTime(MString, UTC)", "UTC string", "The deprecated UTC parser still constructs the expected time",
+                        UTC.GetLongIntsString() == "0.000000123") && Passed;
+
+  MTime SQL("1970-01-01 00:00:00", MTime::SQL);
+  Passed = EvaluateTrue("MTime(MString, SQL)", "SQL string", "The deprecated SQL parser still constructs the expected time",
+                        SQL.GetLongIntsString() == "0.000000000") && Passed;
+
+  MTime SQLU("1970-01-01_00:00:00", MTime::SQLU);
+  Passed = EvaluateTrue("MTime(MString, SQLU)", "SQLU string", "The deprecated SQLU parser still constructs the expected time",
+                        SQLU.GetLongIntsString() == "0.000000000") && Passed;
+
+  MTime Short("19700101_000000", MTime::Short);
+  Passed = EvaluateTrue("MTime(MString, Short)", "short string", "The deprecated short parser still constructs the expected time",
+                        Short.GetLongIntsString() == "0.000000000") && Passed;
+
+  mout.Enable(false);
+  MTime Invalid("wrong", MTime::SQL);
+  mout.Enable(true);
+  Passed = EvaluateTrue("MTime(MString, Format)", "invalid format", "Invalid formatted input falls back to the epoch",
+                        Invalid.GetLongIntsString() == "0.000000000") && Passed;
+
+  MTime FormatTime(0L, 123456789L);
+  Passed = EvaluateTrue("GetString()", "human readable", "GetString returns the documented human-readable format",
+                        FormatTime.GetString() == "Seconds since epoch:   0.123457") && Passed;
+  Passed = EvaluateTrue("GetLongIntsString()", "long ints", "GetLongIntsString returns the seconds.nanoseconds layout",
+                        FormatTime.GetLongIntsString() == "0.123456789") && Passed;
+  Passed = EvaluateTrue("GetUTCString()", "UTC", "GetUTCString returns the documented UTC layout",
+                        FormatTime.GetUTCString() == "01.01.1970 00:00:00:123456789") && Passed;
+  Passed = EvaluateTrue("GetSQLString()", "SQL", "GetSQLString returns the documented SQL layout",
+                        FormatTime.GetSQLString() == "1970-01-01 00:00:00") && Passed;
+  Passed = EvaluateTrue("GetSQLUString()", "SQLU", "GetSQLUString returns the documented SQLU layout",
+                        FormatTime.GetSQLUString() == "1970-01-01_00:00:00") && Passed;
+  Passed = EvaluateTrue("GetShortString()", "short", "GetShortString returns the compact timestamp layout",
+                        FormatTime.GetShortString() == "19700101_000000") && Passed;
+  Passed = EvaluateTrue("GetFitsDateString()", "FITS date", "GetFitsDateString returns the FITS-style date layout",
+                        FormatTime.GetFitsDateString() == "01/01/70") && Passed;
+  Passed = EvaluateTrue("GetFitsTimeString()", "FITS time", "GetFitsTimeString returns the FITS-style time layout",
+                        FormatTime.GetFitsTimeString() == "00:00:00") && Passed;
+
+  ostringstream Out;
+  Out << FormatTime;
+  Passed = EvaluateTrue("operator<<", "stream formatting", "The stream operator forwards to GetLongIntsString()",
+                        Out.str() == "0.123456789") && Passed;
+
+  return Passed;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+//! Test calendar and conversion helpers
+bool UTTime::TestCalendarAndConversions()
+{
+  bool Passed = true;
+
+  MTime Epoch(1970, 1, 1, 0, 0, 0, 123456789);
+  Passed = EvaluateNear("GetAsDouble()", "epoch", "GetAsDouble matches GetAsSeconds()", Epoch.GetAsDouble(), 0.123456789, 1e-12) && Passed;
+  Passed = EvaluateNear("GetAsSeconds()", "epoch", "GetAsSeconds includes fractional nanoseconds", Epoch.GetAsSeconds(), 0.123456789, 1e-12) && Passed;
+  Passed = EvaluateNear("GetAsSystemSeconds()", "epoch", "GetAsSystemSeconds returns the stored whole seconds", Epoch.GetAsSystemSeconds(), 0.0, 1e-12) && Passed;
+  Passed = EvaluateNear("GetAsJulianDay()", "epoch", "GetAsJulianDay returns the documented Julian day for the Unix epoch",
+                        Epoch.GetAsJulianDay(), 2440587.500001429, 1e-9) && Passed;
+
+  Passed = EvaluateNear("GetYears()", "epoch", "GetYears returns the calendar year", Epoch.GetYears(), 1970.0, 1e-12) && Passed;
+  Passed = EvaluateNear("GetMonths()", "epoch", "GetMonths returns the calendar month", Epoch.GetMonths(), 1.0, 1e-12) && Passed;
+  Passed = EvaluateNear("GetDays()", "epoch", "GetDays returns the calendar day", Epoch.GetDays(), 1.0, 1e-12) && Passed;
+  Passed = EvaluateNear("GetHours()", "epoch", "GetHours returns the calendar hour", Epoch.GetHours(), 0.0, 1e-12) && Passed;
+  Passed = EvaluateNear("GetMinutes()", "epoch", "GetMinutes returns the calendar minute", Epoch.GetMinutes(), 0.0, 1e-12) && Passed;
+  Passed = EvaluateNear("GetSeconds()", "epoch", "GetSeconds returns the calendar second", Epoch.GetSeconds(), 0.0, 1e-12) && Passed;
+  Passed = EvaluateNear("GetNanoSeconds()", "epoch", "GetNanoSeconds returns the stored nanoseconds", Epoch.GetNanoSeconds(), 123456789.0, 1e-12) && Passed;
+
+  MTime LeapYearMiddle(2000, 7, 2, 12, 0, 0, 0);
+  Passed = EvaluateTrue("GetAsYears()", "middle of leap year", "GetAsYears stays within the expected calendar year bounds",
+                        LeapYearMiddle.GetAsYears() > 2000.49 && LeapYearMiddle.GetAsYears() < 2000.51) && Passed;
+
+  mout.Enable(false);
+  unsigned int DaysSinceEpoch = Epoch.GetDaysSinceEpoch();
+  mout.Enable(true);
+  Passed = EvaluateNear("GetDaysSinceEpoch()", "epoch", "GetDaysSinceEpoch returns zero for the epoch", DaysSinceEpoch, 0.0, 1e-12) && Passed;
+
+  Passed = EvaluateNear("BusyWait()", "zero microseconds", "BusyWait returns zero", MTime::BusyWait(0), 0.0, 1e-12) && Passed;
+
+  MTime BeforeNow;
+  BeforeNow.Set(0.0);
+  Passed = EvaluateTrue("GetElapsedSeconds()", "epoch", "GetElapsedSeconds is positive for a time in the past", BeforeNow.GetElapsedSeconds() > 0.0) && Passed;
+
+  return Passed;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+int main()
+{
+  UTTime Test;
+  return Test.Run() == true ? 0 : 1;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
I cherry-picked two commits from `zoglauer/megalib:feature/unittests-2026` that update `MTime` to interpret times in UTC rather than local time. This is required for `nuclearizer` to get consistent results when running code, regardless of the local time of the machine that is running the code.

While this PR is also adding documentation comments and unit tests (let me know if you want me to remove the latter), the biggest change is going from `mktime`/`localtime` to `gmtime`.