### PR TITLE
Add the SecondaryParticleID to the OI info of the tra file

### DIFF
--- a/src/global/misc/inc/MPhysicalEvent.h
+++ b/src/global/misc/inc/MPhysicalEvent.h
@@ -124,7 +124,7 @@ class MPhysicalEvent : public MRotationInterface
   const MPhysicalEventHit& GetHit(unsigned int i) const;
   
   //! Set the OI information
-  void SetOIInformation(const MVector Position, const MVector Direction, const MVector Polarization, const double Energy) { m_OIPosition = Position; m_OIDirection = Direction; m_OIPolarization = Polarization, m_OIEnergy = Energy; }
+  void SetOIInformation(const MVector Position, const MVector Direction, const MVector Polarization, const double Energy, const int SecondaryId) { m_OIPosition = Position; m_OIDirection = Direction; m_OIPolarization = Polarization, m_OIEnergy = Energy, m_OISecondaryId = SecondaryId ; }
   //! Get the OI position information
   MVector GetOIPosition() const { return m_OIPosition; }
   //! Get the OI direction information
@@ -201,7 +201,9 @@ class MPhysicalEvent : public MRotationInterface
   MVector m_OIPolarization;
   //! OI energy (the meaning is a secret...)
   double m_OIEnergy;
-
+  //! OI Secondary Id (the meaning is a secret...)
+  int m_OISecondaryId;
+  
   //! Store the read lines for delayed parsing
   vector<MString> m_Lines; 
 

--- a/src/global/misc/inc/MPhysicalEvent.h
+++ b/src/global/misc/inc/MPhysicalEvent.h
@@ -124,7 +124,7 @@ class MPhysicalEvent : public MRotationInterface
   const MPhysicalEventHit& GetHit(unsigned int i) const;
   
   //! Set the OI information
-  void SetOIInformation(const MVector Position, const MVector Direction, const MVector Polarization, const double Energy, const int SecondaryId) { m_OIPosition = Position; m_OIDirection = Direction; m_OIPolarization = Polarization, m_OIEnergy = Energy, m_OISecondaryId = SecondaryId ; }
+  void SetOIInformation(const MVector Position, const MVector Direction, const MVector Polarization, const double Energy, const int ParticleId) { m_OIPosition = Position; m_OIDirection = Direction; m_OIPolarization = Polarization, m_OIEnergy = Energy, m_OIParticleId = ParticleId ; }
   //! Get the OI position information
   MVector GetOIPosition() const { return m_OIPosition; }
   //! Get the OI direction information
@@ -202,7 +202,7 @@ class MPhysicalEvent : public MRotationInterface
   //! OI energy (the meaning is a secret...)
   double m_OIEnergy;
   //! OI Secondary Id (the meaning is a secret...)
-  int m_OISecondaryId;
+  int m_OIParticleId;
   
   //! Store the read lines for delayed parsing
   vector<MString> m_Lines; 

--- a/src/global/misc/src/MPhysicalEvent.cxx
+++ b/src/global/misc/src/MPhysicalEvent.cxx
@@ -321,7 +321,7 @@ MString MPhysicalEvent::ToTraString() const
     S<<"DC"<<endl;
   }
   if (m_OIPosition != g_VectorNotDefined && m_OIDirection != g_VectorNotDefined && m_OIPolarization != g_VectorNotDefined) {
-    S<<"OI "<<m_OIPosition.X()<<" "<<m_OIPosition.Y()<<" "<<m_OIPosition.Z()<<" "<<m_OIDirection.X()<<" "<<m_OIDirection.Y()<<" "<<m_OIDirection.Z()<<" "<<m_OIPolarization.X()<<" "<<m_OIPolarization.Y()<<" "<<m_OIPolarization.Z()<<" "<<m_OIEnergy<<endl <<" "<<m_OISecondaryId<<endl;
+    S<<"OI "<<m_OIPosition.X()<<" "<<m_OIPosition.Y()<<" "<<m_OIPosition.Z()<<" "<<m_OIDirection.X()<<" "<<m_OIDirection.Y()<<" "<<m_OIDirection.Z()<<" "<<m_OIPolarization.X()<<" "<<m_OIPolarization.Y()<<" "<<m_OIPolarization.Z()<<" "<<m_OIEnergy <<" "<<m_OISecondaryId<<endl;
   }
   for (unsigned int c = 0; c < m_Comments.size(); ++c) {
     S<<"CC "<<m_Comments[c]<<endl;
@@ -538,7 +538,7 @@ int MPhysicalEvent::ParseLine(const char* Line, bool Fast)
       m_OISecondaryId = strtod(p, NULL);
     } else {
       if (sscanf(Line, "OI %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %d", &m_OIPosition[0], &m_OIPosition[1], &m_OIPosition[2], &m_OIDirection[0], &m_OIDirection[1], &m_OIDirection[2], &m_OIPolarization[0], &m_OIPolarization[1], &m_OIPolarization[2], &m_OIEnergy, &m_OISecondaryId) != 11) {
-        Ret = 1;
+        Ret = 1; 
       }
     }
   } else if (Line[0] == 'D' && Line[1] == 'C') {

--- a/src/global/misc/src/MPhysicalEvent.cxx
+++ b/src/global/misc/src/MPhysicalEvent.cxx
@@ -141,7 +141,7 @@ bool MPhysicalEvent::Assimilate(MPhysicalEvent* E)
   m_OIDirection = E->m_OIDirection;
   m_OIPolarization = E->m_OIPolarization;
   m_OIEnergy = E->m_OIEnergy;  
-  m_OISecondaryId = E->m_OISecondaryId;
+  m_OIParticleId = E->m_OIParticleId;
   
   return true;
 }
@@ -182,7 +182,7 @@ void MPhysicalEvent::Reset()
   m_OIDirection = g_VectorNotDefined;
   m_OIPolarization = g_VectorNotDefined;
   m_OIEnergy = g_DoubleNotDefined;
-  m_OISecondaryId = g_IntNotDefined;
+  m_OIParticleId = g_IntNotDefined;
   
   m_Lines.clear();
   m_Comments.clear();
@@ -321,7 +321,7 @@ MString MPhysicalEvent::ToTraString() const
     S<<"DC"<<endl;
   }
   if (m_OIPosition != g_VectorNotDefined && m_OIDirection != g_VectorNotDefined && m_OIPolarization != g_VectorNotDefined) {
-    S<<"OI "<<m_OIPosition.X()<<" "<<m_OIPosition.Y()<<" "<<m_OIPosition.Z()<<" "<<m_OIDirection.X()<<" "<<m_OIDirection.Y()<<" "<<m_OIDirection.Z()<<" "<<m_OIPolarization.X()<<" "<<m_OIPolarization.Y()<<" "<<m_OIPolarization.Z()<<" "<<m_OIEnergy <<" "<<m_OISecondaryId<<endl;
+    S<<"OI "<<m_OIPosition.X()<<" "<<m_OIPosition.Y()<<" "<<m_OIPosition.Z()<<" "<<m_OIDirection.X()<<" "<<m_OIDirection.Y()<<" "<<m_OIDirection.Z()<<" "<<m_OIPolarization.X()<<" "<<m_OIPolarization.Y()<<" "<<m_OIPolarization.Z()<<" "<<m_OIEnergy <<" "<<m_OIParticleId<<endl;
   }
   for (unsigned int c = 0; c < m_Comments.size(); ++c) {
     S<<"CC "<<m_Comments[c]<<endl;
@@ -534,13 +534,35 @@ int MPhysicalEvent::ParseLine(const char* Line, bool Fast)
       m_OIPolarization[0] = strtod(p, &p);
       m_OIPolarization[1] = strtod(p, &p);
       m_OIPolarization[2] = strtod(p, &p);
-      m_OIEnergy = strtod(p, &p);
-      m_OISecondaryId = (int)strtol(p, NULL, 10);
+      
+      // Read the 10th value (Energy)
+      char* next_p;
+      m_OIEnergy = strtod(p, &next_p);
+      // RETROCOMPATIBILITY CHECK:
+      // If next_p points to the exact same position as p, no characters were consumed.
+      // Or, if it reached the end of the string, there is no ID to read.
+    if (p == next_p || *next_p == '\0' || *next_p == '\n' || *next_p == '\r') {
+      m_OIParticleId = 0; // Set a default value for old files
     } else {
-      if (sscanf(Line, "OI %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %d", &m_OIPosition[0], &m_OIPosition[1], &m_OIPosition[2], &m_OIDirection[0], &m_OIDirection[1], &m_OIDirection[2], &m_OIPolarization[0], &m_OIPolarization[1], &m_OIPolarization[2], &m_OIEnergy, &m_OISecondaryId) != 11) {
-        Ret = 1; 
-      }
+      m_OIParticleId = (int)strtol(next_p, NULL, 10); // Read the ID for new files
     }
+      
+    } else {
+      // Try reading all 11 items first (New File Format)
+    int parsed = sscanf(Line, "OI %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %d", 
+                        &m_OIPosition[0], &m_OIPosition[1], &m_OIPosition[2], 
+                        &m_OIDirection[0], &m_OIDirection[1], &m_OIDirection[2], 
+                        &m_OIPolarization[0], &m_OIPolarization[1], &m_OIPolarization[2], 
+                        &m_OIEnergy, &m_OIParticleId);
+    
+    if (parsed == 10) {
+      // RETROCOMPATIBILITY: It's an old file (only 10 numbers successfully parsed)
+      m_OIParticleId = 0; // Assign your default old-file ID
+    } else if (parsed != 11) {
+      // It's broken text (neither 10 nor 11 numbers parsed successfully)
+      Ret = 1; 
+    }
+   }
   } else if (Line[0] == 'D' && Line[1] == 'C') {
     m_Decay = true;
   } else if (Line[0] == 'S' && Line[1] == 'E') {

--- a/src/global/misc/src/MPhysicalEvent.cxx
+++ b/src/global/misc/src/MPhysicalEvent.cxx
@@ -320,7 +320,7 @@ MString MPhysicalEvent::ToTraString() const
   if (m_Decay == true) {
     S<<"DC"<<endl;
   }
-  if (m_OIPosition != g_VectorNotDefined && m_OIDirection != g_VectorNotDefined && m_OIPolarization != g_VectorNotDefined) {
+  if (m_OIPosition != g_VectorNotDefined && m_OIDirection != g_VectorNotDefined && m_OIPolarization != g_VectorNotDefined && m_OIParticleId != g_IntNotDefined ) {
     S<<"OI "<<m_OIPosition.X()<<" "<<m_OIPosition.Y()<<" "<<m_OIPosition.Z()<<" "<<m_OIDirection.X()<<" "<<m_OIDirection.Y()<<" "<<m_OIDirection.Z()<<" "<<m_OIPolarization.X()<<" "<<m_OIPolarization.Y()<<" "<<m_OIPolarization.Z()<<" "<<m_OIEnergy <<" "<<m_OIParticleId<<endl;
   }
   for (unsigned int c = 0; c < m_Comments.size(); ++c) {

--- a/src/global/misc/src/MPhysicalEvent.cxx
+++ b/src/global/misc/src/MPhysicalEvent.cxx
@@ -141,6 +141,7 @@ bool MPhysicalEvent::Assimilate(MPhysicalEvent* E)
   m_OIDirection = E->m_OIDirection;
   m_OIPolarization = E->m_OIPolarization;
   m_OIEnergy = E->m_OIEnergy;  
+  m_OISecondaryId = E->m_OISecondaryId;
   
   return true;
 }
@@ -181,7 +182,8 @@ void MPhysicalEvent::Reset()
   m_OIDirection = g_VectorNotDefined;
   m_OIPolarization = g_VectorNotDefined;
   m_OIEnergy = g_DoubleNotDefined;
-
+  m_OISecondaryId = g_IntNotDefined;
+  
   m_Lines.clear();
   m_Comments.clear();
 }
@@ -319,7 +321,7 @@ MString MPhysicalEvent::ToTraString() const
     S<<"DC"<<endl;
   }
   if (m_OIPosition != g_VectorNotDefined && m_OIDirection != g_VectorNotDefined && m_OIPolarization != g_VectorNotDefined) {
-    S<<"OI "<<m_OIPosition.X()<<" "<<m_OIPosition.Y()<<" "<<m_OIPosition.Z()<<" "<<m_OIDirection.X()<<" "<<m_OIDirection.Y()<<" "<<m_OIDirection.Z()<<" "<<m_OIPolarization.X()<<" "<<m_OIPolarization.Y()<<" "<<m_OIPolarization.Z()<<" "<<m_OIEnergy<<endl;
+    S<<"OI "<<m_OIPosition.X()<<" "<<m_OIPosition.Y()<<" "<<m_OIPosition.Z()<<" "<<m_OIDirection.X()<<" "<<m_OIDirection.Y()<<" "<<m_OIDirection.Z()<<" "<<m_OIPolarization.X()<<" "<<m_OIPolarization.Y()<<" "<<m_OIPolarization.Z()<<" "<<m_OIEnergy<<endl <<" "<<m_OISecondaryId<<endl;
   }
   for (unsigned int c = 0; c < m_Comments.size(); ++c) {
     S<<"CC "<<m_Comments[c]<<endl;
@@ -533,8 +535,9 @@ int MPhysicalEvent::ParseLine(const char* Line, bool Fast)
       m_OIPolarization[1] = strtod(p, &p);
       m_OIPolarization[2] = strtod(p, &p);
       m_OIEnergy = strtod(p, NULL);
+      m_OISecondaryId = strtod(p, NULL);
     } else {
-      if (sscanf(Line, "OI %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf", &m_OIPosition[0], &m_OIPosition[1], &m_OIPosition[2], &m_OIDirection[0], &m_OIDirection[1], &m_OIDirection[2], &m_OIPolarization[0], &m_OIPolarization[1], &m_OIPolarization[2], &m_OIEnergy) != 10) {
+      if (sscanf(Line, "OI %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %d", &m_OIPosition[0], &m_OIPosition[1], &m_OIPosition[2], &m_OIDirection[0], &m_OIDirection[1], &m_OIDirection[2], &m_OIPolarization[0], &m_OIPolarization[1], &m_OIPolarization[2], &m_OIEnergy, &m_OISecondaryId) != 11) {
         Ret = 1;
       }
     }

--- a/src/global/misc/src/MPhysicalEvent.cxx
+++ b/src/global/misc/src/MPhysicalEvent.cxx
@@ -534,8 +534,8 @@ int MPhysicalEvent::ParseLine(const char* Line, bool Fast)
       m_OIPolarization[0] = strtod(p, &p);
       m_OIPolarization[1] = strtod(p, &p);
       m_OIPolarization[2] = strtod(p, &p);
-      m_OIEnergy = strtod(p, NULL);
-      m_OISecondaryId = strtod(p, NULL);
+      m_OIEnergy = strtod(p, &p);
+      m_OISecondaryId = (int)strtol(p, NULL, 10);
     } else {
       if (sscanf(Line, "OI %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %d", &m_OIPosition[0], &m_OIPosition[1], &m_OIPosition[2], &m_OIDirection[0], &m_OIDirection[1], &m_OIDirection[2], &m_OIPolarization[0], &m_OIPolarization[1], &m_OIPolarization[2], &m_OIEnergy, &m_OISecondaryId) != 11) {
         Ret = 1; 

--- a/src/revan/inc/MREAMStartInformation.h
+++ b/src/revan/inc/MREAMStartInformation.h
@@ -72,7 +72,7 @@ class MREAMStartInformation : public MREAM
   //! Return original energy 
   double GetEnergy() const { return m_Energy; }
   //! Return original Secondary Id 
-  int GetSecondaryId() const { return m_SecondaryId; }
+  int GetParticleId() const { return m_ParticleId; }
 
   // protected methods:
  protected:
@@ -94,7 +94,7 @@ class MREAMStartInformation : public MREAM
   //! Original energy
   double m_Energy;
   //! Original Id
-  int m_SecondaryId;
+  int m_ParticleId;
   
 #ifdef ___CLING___
  public:

--- a/src/revan/inc/MREAMStartInformation.h
+++ b/src/revan/inc/MREAMStartInformation.h
@@ -62,7 +62,7 @@ class MREAMStartInformation : public MREAM
   //! Set original energy
   void SetEnergy(const double Energy) { m_Energy = Energy; }
   //! Set original Secondary Id
-  void SetSecondaryId(const int Id) { m_SecondaryId = Id; }
+  void SetParticleId(const int Id) { m_ParticleId = Id; }
   //! Return original position
   MVector GetPosition() const { return m_Position; }
   //! Return original position

--- a/src/revan/inc/MREAMStartInformation.h
+++ b/src/revan/inc/MREAMStartInformation.h
@@ -61,6 +61,8 @@ class MREAMStartInformation : public MREAM
   void SetPolarization(const MVector Polarization) { m_Polarization = Polarization; }
   //! Set original energy
   void SetEnergy(const double Energy) { m_Energy = Energy; }
+  //! Set original Secondary Id
+  void SetSecondaryId(const int Id) { m_SecondaryId = Id; }
   //! Return original position
   MVector GetPosition() const { return m_Position; }
   //! Return original position
@@ -69,6 +71,8 @@ class MREAMStartInformation : public MREAM
   MVector GetDirection() const { return m_Direction; }
   //! Return original energy 
   double GetEnergy() const { return m_Energy; }
+  //! Return original Secondary Id 
+  int GetSecondaryId() const { return m_SecondaryId; }
 
   // protected methods:
  protected:
@@ -89,7 +93,9 @@ class MREAMStartInformation : public MREAM
   MVector m_Polarization;
   //! Original energy
   double m_Energy;
-
+  //! Original Id
+  int m_SecondaryId;
+  
 #ifdef ___CLING___
  public:
   ClassDef(MREAMStartInformation, 0) // no description

--- a/src/revan/inc/MRERawEvent.h
+++ b/src/revan/inc/MRERawEvent.h
@@ -84,7 +84,7 @@ class MRERawEvent : public MRESE, public MRotationInterface
   MString GetEventTypeAsString();
   
   //! Set origin information
-  void SetOriginInformation(MVector Position, MVector Direction, MVector Polarization, double Energy, int SecondaryId);
+  void SetOriginInformation(MVector Position, MVector Direction, MVector Polarization, double Energy, int ParticleId);
   
   
   //! Return the complete energy of this event

--- a/src/revan/inc/MRERawEvent.h
+++ b/src/revan/inc/MRERawEvent.h
@@ -84,7 +84,7 @@ class MRERawEvent : public MRESE, public MRotationInterface
   MString GetEventTypeAsString();
   
   //! Set origin information
-  void SetOriginInformation(MVector Position, MVector Direction, MVector Polarization, double Energy);
+  void SetOriginInformation(MVector Position, MVector Direction, MVector Polarization, double Energy, int SecondaryId);
   
   
   //! Return the complete energy of this event

--- a/src/revan/src/MFileEventsEvta.cxx
+++ b/src/revan/src/MFileEventsEvta.cxx
@@ -317,10 +317,11 @@ MRERawEvent* MFileEventsEvta::GetNextEventASCII()
         if (Line[0] == 'I' && Line[1] == 'A') {
           if (Line[3] == 'I' && Line[4] == 'N' && Line[5] == 'I' && Line[6] == 'T') {
             double x, y, z, dx, dy, dz, px, py, pz, e;
-            if (sscanf(Line.Data(), "IA INIT %*d;%*d;%*d;%*f;%lf;%lf;%lf;%*d;%*f;%*f;%*f;%*f;%*f;%*f;%*f;%*d;%lf;%lf;%lf;%lf;%lf;%lf;%lf",
-              &x, &y, &z, &dx, &dy, &dz, &px, &py, &pz, &e) == 10) {
+	    int id;
+            if (sscanf(Line.Data(), "IA INIT %*d;%*d;%*d;%*f;%lf;%lf;%lf;%*d;%*f;%*f;%*f;%*f;%*f;%*f;%*f;%d;%lf;%lf;%lf;%lf;%lf;%lf;%lf",
+              &x, &y, &z, &id, &dx, &dy, &dz, &px, &py, &pz, &e) == 11) {
               ostringstream out;
-              out<<"OI "<<x<<";"<<y<<";"<<z<<";"<<dx<<";"<<dy<<";"<<dz<<";"<<px<<";"<<py<<";"<<pz<<";"<<e<<endl;
+              out<<"OI "<<x<<";"<<y<<";"<<z<<";"<<dx<<";"<<dy<<";"<<dz<<";"<<px<<";"<<py<<";"<<pz<<";"<<e<<";"<<id<<endl;
               Line = out.str().c_str();
             }
           }

--- a/src/revan/src/MFileEventsEvta.cxx
+++ b/src/revan/src/MFileEventsEvta.cxx
@@ -494,7 +494,7 @@ MRERawEvent* MFileEventsEvta::GetNextEventBinary()
           Event->AddREAM(GR);
         }
         if (m_SaveOI == true && SimEvent->GetNIAs() > 0) {
-          Event->SetOriginInformation(SimEvent->GetIAAt(0)->GetPosition(), SimEvent->GetIAAt(0)->GetSecondaryDirection(), SimEvent->GetIAAt(0)->GetSecondaryPolarization(), SimEvent->GetIAAt(0)->GetSecondaryEnergy(),SimEvent->GetIAAt(0)->GetSecondaryParticleID());
+          Event->SetOriginInformation(SimEvent->GetIAAt(0)->GetPosition(), SimEvent->GetIAAt(0)->GetSecondaryDirection(), SimEvent->GetIAAt(0)->GetSecondaryPolarization(), SimEvent->GetIAAt(0)->GetSecondaryEnergy(),SimEvent->GetIAAt(0)->GetParticleID());
         }
         
         delete SimEvent;

--- a/src/revan/src/MFileEventsEvta.cxx
+++ b/src/revan/src/MFileEventsEvta.cxx
@@ -493,7 +493,7 @@ MRERawEvent* MFileEventsEvta::GetNextEventBinary()
           Event->AddREAM(GR);
         }
         if (m_SaveOI == true && SimEvent->GetNIAs() > 0) {
-          Event->SetOriginInformation(SimEvent->GetIAAt(0)->GetPosition(), SimEvent->GetIAAt(0)->GetSecondaryDirection(), SimEvent->GetIAAt(0)->GetSecondaryPolarization(), SimEvent->GetIAAt(0)->GetSecondaryEnergy());
+          Event->SetOriginInformation(SimEvent->GetIAAt(0)->GetPosition(), SimEvent->GetIAAt(0)->GetSecondaryDirection(), SimEvent->GetIAAt(0)->GetSecondaryPolarization(), SimEvent->GetIAAt(0)->GetSecondaryEnergy(),SimEvent->GetIAAt(0)->GetSecondaryParticleID());
         }
         
         delete SimEvent;

--- a/src/revan/src/MREAMStartInformation.cxx
+++ b/src/revan/src/MREAMStartInformation.cxx
@@ -56,7 +56,7 @@ MREAMStartInformation::MREAMStartInformation() : MREAM()
   m_Direction = MVector(0.0, 0.0, 0.0);
   m_Polarization = MVector(0.0, 0.0, 0.0);
   m_Energy = 0.0;
-  m_SecondaryId = 0;
+  m_ParticleId = 0;
 }
 
 
@@ -73,7 +73,7 @@ MREAMStartInformation::MREAMStartInformation(const MREAMStartInformation& REAM)
   m_Direction = REAM.m_Direction;
   m_Polarization = REAM.m_Polarization;
   m_Energy = REAM.m_Energy;
-  m_SecondaryId = REAM.m_SecondaryId;
+  m_ParticleId = REAM.m_SecondaryId;
 }
 
 

--- a/src/revan/src/MREAMStartInformation.cxx
+++ b/src/revan/src/MREAMStartInformation.cxx
@@ -56,6 +56,7 @@ MREAMStartInformation::MREAMStartInformation() : MREAM()
   m_Direction = MVector(0.0, 0.0, 0.0);
   m_Polarization = MVector(0.0, 0.0, 0.0);
   m_Energy = 0.0;
+  m_SecondaryId = 0;
 }
 
 
@@ -72,6 +73,7 @@ MREAMStartInformation::MREAMStartInformation(const MREAMStartInformation& REAM)
   m_Direction = REAM.m_Direction;
   m_Polarization = REAM.m_Polarization;
   m_Energy = REAM.m_Energy;
+  m_SecondaryId = REAM.m_SecondaryId;
 }
 
 

--- a/src/revan/src/MREAMStartInformation.cxx
+++ b/src/revan/src/MREAMStartInformation.cxx
@@ -73,7 +73,7 @@ MREAMStartInformation::MREAMStartInformation(const MREAMStartInformation& REAM)
   m_Direction = REAM.m_Direction;
   m_Polarization = REAM.m_Polarization;
   m_Energy = REAM.m_Energy;
-  m_ParticleId = REAM.m_SecondaryId;
+  m_ParticleId = REAM.m_ParticleId;
 }
 
 

--- a/src/revan/src/MRERawEvent.cxx
+++ b/src/revan/src/MRERawEvent.cxx
@@ -1261,7 +1261,7 @@ MString MRERawEvent::ToCompactString()
 
   ED1 = m_Start->GetEnergy();
   ED2 = GetEnergy() - ED1;
-
+  
 
   if (m_Start->GetType() == MRESE::c_Track) {
     snprintf(Text, Length,

--- a/src/revan/src/MRERawEvent.cxx
+++ b/src/revan/src/MRERawEvent.cxx
@@ -450,14 +450,14 @@ double MRERawEvent::GetEnergy()
 
 
 //! Set origin information
-void MRERawEvent::SetOriginInformation(MVector Position, MVector Direction, MVector Polarization, double Energy, int SecondaryId)
+void MRERawEvent::SetOriginInformation(MVector Position, MVector Direction, MVector Polarization, double Energy, int ParticleId)
 {
   MREAMStartInformation* OI = new MREAMStartInformation();
   OI->SetPosition(Position);
   OI->SetDirection(Direction);
   OI->SetPolarization(Polarization);
   OI->SetEnergy(Energy);
-  OI->SetSecondaryId(SecondaryId);
+  OI->SetParticleId(ParticleId);
   
   m_Measurements.push_back(OI);
 }
@@ -1203,7 +1203,7 @@ MPhysicalEvent* MRERawEvent::GetPhysicalEvent()
   for (unsigned int m = 0; m < m_Measurements.size(); ++m) {
     if (m_Measurements[m]->GetType() == MREAM::c_StartInformation) {
       MREAMStartInformation* Start = dynamic_cast<MREAMStartInformation*>(m_Measurements[m]);
-      m_Event->SetOIInformation(Start->GetPosition(), Start->GetDirection(), Start->GetPolarization(), Start->GetEnergy(), Start->GetSecondaryId());
+      m_Event->SetOIInformation(Start->GetPosition(), Start->GetDirection(), Start->GetPolarization(), Start->GetEnergy(), Start->GetParticleId());
     }
   }
   m_Event->ClearComments(); // Since this info might be added multiple times.

--- a/src/revan/src/MRERawEvent.cxx
+++ b/src/revan/src/MRERawEvent.cxx
@@ -1843,7 +1843,7 @@ int MRERawEvent::ParseLine(const char* Line, int Version)
       Start->SetDirection(MVector(dx, dy, dz));
       Start->SetPolarization(MVector(px, py, pz));
       Start->SetEnergy(e);
-      Start->SetSecondaryId(id);
+      Start->SetParticleId(id);
       m_Measurements.push_back(Start);
     } else {
       Ret = 1;

--- a/src/revan/src/MRERawEvent.cxx
+++ b/src/revan/src/MRERawEvent.cxx
@@ -1261,7 +1261,7 @@ MString MRERawEvent::ToCompactString()
 
   ED1 = m_Start->GetEnergy();
   ED2 = GetEnergy() - ED1;
-  
+
 
   if (m_Start->GetType() == MRESE::c_Track) {
     snprintf(Text, Length,

--- a/src/revan/src/MRERawEvent.cxx
+++ b/src/revan/src/MRERawEvent.cxx
@@ -450,13 +450,14 @@ double MRERawEvent::GetEnergy()
 
 
 //! Set origin information
-void MRERawEvent::SetOriginInformation(MVector Position, MVector Direction, MVector Polarization, double Energy)
+void MRERawEvent::SetOriginInformation(MVector Position, MVector Direction, MVector Polarization, double Energy, int SecondaryId)
 {
   MREAMStartInformation* OI = new MREAMStartInformation();
   OI->SetPosition(Position);
   OI->SetDirection(Direction);
   OI->SetPolarization(Polarization);
   OI->SetEnergy(Energy);
+  OI->SetSecondaryId(SecondaryId);
   
   m_Measurements.push_back(OI);
 }
@@ -1202,7 +1203,7 @@ MPhysicalEvent* MRERawEvent::GetPhysicalEvent()
   for (unsigned int m = 0; m < m_Measurements.size(); ++m) {
     if (m_Measurements[m]->GetType() == MREAM::c_StartInformation) {
       MREAMStartInformation* Start = dynamic_cast<MREAMStartInformation*>(m_Measurements[m]);
-      m_Event->SetOIInformation(Start->GetPosition(), Start->GetDirection(), Start->GetPolarization(), Start->GetEnergy());
+      m_Event->SetOIInformation(Start->GetPosition(), Start->GetDirection(), Start->GetPolarization(), Start->GetEnergy(), Start->GetSecondaryId());
     }
   }
   m_Event->ClearComments(); // Since this info might be added multiple times.
@@ -1835,12 +1836,14 @@ int MRERawEvent::ParseLine(const char* Line, int Version)
     double py = 0.0;
     double pz = 0.0;
     double e = 0.0;
-    if (sscanf(Line, "OI %lf;%lf;%lf;%lf;%lf;%lf;%lf;%lf;%lf;%lf", &x, &y, &z, &dx, &dy, &dz, &px, &py, &pz, &e) == 10) {
+    int id = 0;
+    if (sscanf(Line, "OI %lf;%lf;%lf;%lf;%lf;%lf;%lf;%lf;%lf;%lf;%d", &x, &y, &z, &dx, &dy, &dz, &px, &py, &pz, &e, &id) == 11) {
       MREAMStartInformation* Start = new MREAMStartInformation();
       Start->SetPosition(MVector(x, y, z));
       Start->SetDirection(MVector(dx, dy, dz));
       Start->SetPolarization(MVector(px, py, pz));
       Start->SetEnergy(e);
+      Start->SetSecondaryId(id);
       m_Measurements.push_back(Start);
     } else {
       Ret = 1;

--- a/src/revan/src/MRawEventAnalyzer.cxx
+++ b/src/revan/src/MRawEventAnalyzer.cxx
@@ -520,7 +520,6 @@ bool MRawEventAnalyzer::AddRawEvent(const MString& String, bool NeedsNoising, in
 
   m_EventStore->AddRawEvent(RE);
   
-
   return true;
 }
 

--- a/src/revan/src/MRawEventAnalyzer.cxx
+++ b/src/revan/src/MRawEventAnalyzer.cxx
@@ -492,11 +492,13 @@ bool MRawEventAnalyzer::AddRawEvent(const MString& String, bool NeedsNoising, in
       if (L[0] == 'I' && L[1] == 'A') {
         if (L[3] == 'I' && L[4] == 'N' && L[5] == 'I' && L[6] == 'T') {
           double x, y, z, dx, dy, dz, px, py, pz, e;
-          if (sscanf(L.Data(), "IA INIT %*d;%*d;%*d;%*f;%lf;%lf;%lf;%*d;%*f;%*f;%*f;%*f;%*f;%*f;%*f;%*d;%lf;%lf;%lf;%lf;%lf;%lf;%lf", &x, &y, &z, &dx, &dy, &dz, &px, &py, &pz, &e) == 10) {
+	  int id;
+          if (sscanf(L.Data(), "IA INIT %*d;%*d;%*d;%*f;%lf;%lf;%lf;%*d;%*f;%*f;%*f;%*f;%*f;%*f;%*f;%d;%lf;%lf;%lf;%lf;%lf;%lf;%lf", &x, &y, &z, &id, &dx, &dy, &dz, &px, &py, &pz, &e) == 11) {
             ostringstream out;
-            out<<"OI "<<x<<";"<<y<<";"<<z<<";"<<dx<<";"<<dy<<";"<<dz<<";"<<px<<";"<<py<<";"<<pz<<";"<<e<<endl;
+            out<<"OI "<<x<<";"<<y<<";"<<z<<";"<<dx<<";"<<dy<<";"<<dz<<";"<<px<<";"<<py<<";"<<pz<<";"<<e<<";"<<id<<endl;
             L = out.str().c_str();
           }
+	  
         }
       }
     }
@@ -518,6 +520,7 @@ bool MRawEventAnalyzer::AddRawEvent(const MString& String, bool NeedsNoising, in
 
   m_EventStore->AddRawEvent(RE);
   
+
   return true;
 }
 


### PR DESCRIPTION
This pull request add the `SecondaryParticleID` information in the OI line of the tra file (when revan is run with `--oi`).

This will be useful for the background,for separating the contributions from isotopes to prompt interactions in the detector. 
We will need this for DC5. 