### PR TITLE
Replace 'mout' with 'mdebug' for revan reconstruction

### DIFF
--- a/src/revan/src/MERCSR.cxx
+++ b/src/revan/src/MERCSR.cxx
@@ -188,11 +188,11 @@ MRawEventIncarnations* MERCSR::CreateOnlyPermutations(MRERawEvent* RE)
   // 3 left shift 3... and so on.)
 
   if (RE->GetNRESEs() > m_MaxNInteractions) {
-    mout<<"BCT - Sequence: Too Many hits: "<<RE->GetNRESEs()<<" > "<<m_MaxNInteractions<<endl;
+    mdebug<<"BCT - Sequence: Too Many hits: "<<RE->GetNRESEs()<<" > "<<m_MaxNInteractions<<endl;
     RE->SetRejectionReason(MRERawEvent::c_RejectionTooManyHitsCSR);
     return 0;
   } else if (RE->GetNRESEs() == 0) {
-    mout<<"BCT - Sequence: Event without hits"<<endl;
+    mdebug<<"BCT - Sequence: Event without hits"<<endl;
     RE->SetRejectionReason(MRERawEvent::c_RejectionNoHits);
     return 0; 
   }
@@ -236,7 +236,7 @@ MRawEventIncarnations* MERCSR::CreateOnlyPermutations(MRERawEvent* RE)
 
 void MERCSR::FindComptonSequence(MRERawEvent* RE)
 {
-  mout<<"CSR - Sequence: Searching Compton sequence of event with "
+  mdebug<<"CSR - Sequence: Searching Compton sequence of event with "
       <<RE->GetNRESEs()<<" hits ("<<RE->GetEventID()<<")..."<<endl;
 
   RE->SetComptonQualityFactors(DBL_MAX, DBL_MAX);
@@ -245,11 +245,11 @@ void MERCSR::FindComptonSequence(MRERawEvent* RE)
   
   // Check if we have a 3+ Compton:
   if (RE->GetNRESEs() > m_MaxNInteractions) {
-    mout<<"CSR - Sequence: Too Many hits: "<<RE->GetNRESEs()<<" > "<<m_MaxNInteractions<<endl;
+    mdebug<<"CSR - Sequence: Too Many hits: "<<RE->GetNRESEs()<<" > "<<m_MaxNInteractions<<endl;
     RE->SetRejectionReason(MRERawEvent::c_RejectionTooManyHitsCSR);
     return;
   } else if (RE->GetNRESEs() == 1) {
-    mout<<"CSR - Sequence: Only single hit event!"<<endl;
+    mdebug<<"CSR - Sequence: Only single hit event!"<<endl;
     //RE->SetRejectionReason(MRERawEvent::c_RejectionSingleSiteEvent);
     if (RE->GetRESEAt(0)->GetType() == MRESE::c_Hit || 
         RE->GetRESEAt(0)->GetType() == MRESE::c_Cluster) {
@@ -260,7 +260,7 @@ void MERCSR::FindComptonSequence(MRERawEvent* RE)
     }
     return; 
   } else if (RE->GetNRESEs() == 0) {
-    mout<<"CSR - Sequence: Event without hits"<<endl;
+    mdebug<<"CSR - Sequence: Event without hits"<<endl;
     RE->SetRejectionReason(MRERawEvent::c_RejectionNoHits);
     return; 
   }
@@ -272,24 +272,24 @@ void MERCSR::FindComptonSequence(MRERawEvent* RE)
   if (g_Verbosity >= 1) {
     // Dump all permutations:
     int NShownCombis = 120;
-    mout<<"CSR - Sequence: Top "<< NShownCombis<<" valid permutations ("<<m_QualityFactors.size()<<")"<<endl;
+    mdebug<<"CSR - Sequence: Top "<< NShownCombis<<" valid permutations ("<<m_QualityFactors.size()<<")"<<endl;
     for (m_QualityFactorsIterator = m_QualityFactors.begin(); 
          (m_QualityFactorsIterator != m_QualityFactors.end() && NShownCombis > 0); 
          m_QualityFactorsIterator++, NShownCombis--) {
-      mout<<"   Combi "/*<<m_QualityFactorsIterator*/<<": ";
+      mdebug<<"   Combi "/*<<m_QualityFactorsIterator*/<<": ";
       for (unsigned int r = 0; r < (*m_QualityFactorsIterator).second.size(); ++r) {
-        mout<<(*m_QualityFactorsIterator).second[r]->GetID();
+        mdebug<<(*m_QualityFactorsIterator).second[r]->GetID();
         if ( r < (*m_QualityFactorsIterator).second.size()-1) {
-          mout<<" - ";
+          mdebug<<" - ";
         }
       }
-      mout<<"  -->  "<<(*m_QualityFactorsIterator).first<<endl;
+      mdebug<<"  -->  "<<(*m_QualityFactorsIterator).first<<endl;
     }
   }
 
   if (NGoodSequences == 0) {
     RE->SetRejectionReason(MRERawEvent::c_RejectionCSRNoGoodCombination);
-    mout<<"CSR - Sequence: None of the sequences is valid!"<<endl;
+    mdebug<<"CSR - Sequence: None of the sequences is valid!"<<endl;
     return;    
   }
 
@@ -310,7 +310,7 @@ void MERCSR::FindComptonSequence(MRERawEvent* RE)
   // Test if we have at least one good sequence:
   if (BestQualityFactor == c_CSRFailed) {
     RE->SetRejectionReason(MRERawEvent::c_RejectionCSRNoGoodCombination);
-    mout<<"CSR - Sequence: None of the sequences is valid!"<<endl;
+    mdebug<<"CSR - Sequence: None of the sequences is valid!"<<endl;
     return;    
   }
 
@@ -335,7 +335,7 @@ void MERCSR::FindComptonSequence(MRERawEvent* RE)
   if (BestQualityFactor < m_QualityFactorMin || 
       BestQualityFactor > m_QualityFactorMax) {
     RE->SetRejectionReason(MRERawEvent::c_RejectionCSRThreshold);
-    mout<<"CSR - Sequence: Teststatistics ("<<BestQualityFactor
+    mdebug<<"CSR - Sequence: Teststatistics ("<<BestQualityFactor
         <<") out of threshold ("<<m_QualityFactorMin<<" - "<<m_QualityFactorMax<<")"<<endl;
     return;
   }
@@ -345,8 +345,8 @@ void MERCSR::FindComptonSequence(MRERawEvent* RE)
       BestSequence[0]->GetDetector() != 5 && 
       m_GuaranteeStartD1 == true) {
     RE->SetRejectionReason(MRERawEvent::c_RejectionEventStartNotD1);
-    mout<<"CSR - Sequence: Event starts in not in D1/D5 but in "<<BestSequence[0]->GetDetector()<<endl;
-    mout<<"CSR - Sequence: Good event with TS: "<<BestQualityFactor<<endl;
+    mdebug<<"CSR - Sequence: Event starts in not in D1/D5 but in "<<BestSequence[0]->GetDetector()<<endl;
+    mdebug<<"CSR - Sequence: Good event with TS: "<<BestQualityFactor<<endl;
     return;
   }
  
@@ -360,12 +360,12 @@ void MERCSR::FindComptonSequence(MRERawEvent* RE)
   if (BestSequence[0]->GetType() == MRESE::c_Track && 
       RE->TestElectronDirection(E1, E2) == false) {
     RE->SetRejectionReason(MRERawEvent::c_RejectionElectronDirectionBad);
-    mout<<"CSR - Sequence: Electron direction test failed!"<<endl;
-    mout<<"CSR - Sequence: Good event with TS: "<<BestQualityFactor<<endl;
+    mdebug<<"CSR - Sequence: Electron direction test failed!"<<endl;
+    mdebug<<"CSR - Sequence: Good event with TS: "<<BestQualityFactor<<endl;
     return;
   }
 
-  mout<<"CSR - Sequence: Good event with TS: "<<BestQualityFactor<<endl;
+  mdebug<<"CSR - Sequence: Good event with TS: "<<BestQualityFactor<<endl;
     
   RE->SetComptonQualityFactors(BestQualityFactor, SecondBestQualityFactor);
   RE->SetEventType(MRERawEvent::c_ComptonEvent);


### PR DESCRIPTION
During revan reconstruction, there are too many unnecessary output log that slow down the simulations and makes huge output log file. It should be optional so I replaced the `mout` by `mdebug` . 